### PR TITLE
Start relocating all relevant dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,13 @@ tasks {
 
     shadowJar {
         archiveClassifier.set("")
-        relocate("de.tr7zw.changeme.nbtapi", "com.iridium.iridiumskyblock.nbtapi")
+        relocate("de.tr7zw.changeme.nbtapi", "com.iridium.iridiumskyblock.dependencies.nbtapi")
         relocate("com.iridium.iridiumcolorapi", "com.iridium.iridiumskyblock")
-        relocate("org.yaml.snakeyaml", "com.iridium.iridiumskyblock.snakeyaml")
-        relocate("io.papermc.lib", "com.iridium.iridiumskyblock.paperlib")
+        relocate("org.yaml.snakeyaml", "com.iridium.iridiumskyblock.dependencies.snakeyaml")
+        relocate("io.papermc.lib", "com.iridium.iridiumskyblock.dependencies.paperlib")
+        relocate("com.cryptomorin.xseries", "com.iridium.iridiumskyblock.dependencies.xseries")
+        relocate("com.fasterxml.jackson", "com.iridium.iridiumskyblock.dependencies.fasterxml")
+        relocate("com.j256.ormlite", "com.iridium.iridiumskyblock.dependencies.ormlite")
     }
 
     compileJava {


### PR DESCRIPTION
This change will prevent dependency conflicts with other plugins which are using different versions of the same dependencies