### PR TITLE
Potential fix of java.lang.IllegalArgumentException

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
@@ -604,7 +604,7 @@ public class IslandManager {
                             for (int x = 0; x < 16; x++) {
                                 for (int z = 0; z < 16; z++) {
                                     if (island.isInIsland(x + (chunk.getX() * 16), z + (chunk.getZ() * 16))) {
-                                        final int maxy = chunk.getHighestBlockYAt(x, z);
+                                        final int maxy = Math.min(255, chunk.getHighestBlockYAt(x, z));
                                         for (int y = 0; y <= maxy; y++) {
                                             XMaterial material = IridiumSkyblock.getInstance().getMultiversion().getMaterialAtPosition(chunk, x, y, z);
                                             if (material.equals(XMaterial.AIR)) continue;


### PR DESCRIPTION
Potential fix of exception java.lang.IllegalArgumentException: y out of range (expected 0-255, got 256).
Full log: [https://pastebin.com/FyTqu8bP](https://pastebin.com/FyTqu8bP)
My fix ensures, that `maxy` is lower or equal to 255, by using `Math.min(...)` method.
Please test it before accepting.
