### PR TITLE
Fix spawner delay getting halved multiple times per spawn cycle

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/SpawnerSpawnListener.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/SpawnerSpawnListener.java
@@ -4,13 +4,22 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.IslandBooster;
 import org.bukkit.Bukkit;
+import org.bukkit.block.CreatureSpawner;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.SpawnerSpawnEvent;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class SpawnerSpawnListener implements Listener {
+
+    /**
+     * Spawners spawn multiple entities per SpawnerSpawnEvent.
+     * This list locks the spawner from getting a smaller delay multiple times per cycle.
+     */
+    private List<CreatureSpawner> lock = new ArrayList<>();
 
     @EventHandler
     public void onCreatureSpawn(SpawnerSpawnEvent event) {
@@ -18,9 +27,12 @@ public class SpawnerSpawnListener implements Listener {
         if (island.isPresent()) {
             IslandBooster islandBooster = IridiumSkyblock.getInstance().getIslandManager().getIslandBooster(island.get(), "spawner");
             if (islandBooster.isActive()) {
+                CreatureSpawner spawner = event.getSpawner();
+                lock.add(spawner);
                 Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> {
-                    event.getSpawner().setDelay(event.getSpawner().getDelay() / 2);
-                    event.getSpawner().update();
+                    spawner.setDelay(event.getSpawner().getDelay() / 2);
+                    spawner.update();
+                    lock.remove(spawner);
                 });
             }
         }


### PR DESCRIPTION
closes #87 Fixed the issue by putting the spawner in a lock list and removing it from the lock the next tick, when the spawn delay is halved.