### PR TITLE
Optimize OresUpgrade mechanics

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumskyblock/gui/MissionsGUI.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/gui/MissionsGUI.java
@@ -72,8 +72,8 @@ public class MissionsGUI implements GUI {
                     IslandMission islandMission = IridiumSkyblock.getInstance().getIslandManager().getIslandMission(island, entry.getValue(), entry.getKey(), j);
                     placeholders.add(new Placeholder("progress_" + j, String.valueOf(islandMission.getProgress())));
                 }
-                Integer slot = IridiumSkyblock.getInstance().getMissions().dailySlots.get(i);
-                if (slot != null) {
+                if (IridiumSkyblock.getInstance().getMissions().dailySlots.size() > i) {
+                    Integer slot = IridiumSkyblock.getInstance().getMissions().dailySlots.get(i);
                     inventory.setItem(slot, ItemStackUtils.makeItem(entry.getValue().getItem(), placeholders));
                 }
                 i++;

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
@@ -11,9 +11,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFormEvent;
 
-import java.util.*;
+import java.util.Optional;
+import java.util.Random;
 
 public class BlockFormListener implements Listener {
+
+    private Random random = new Random();
 
     @EventHandler
     public void onBlockForm(BlockFormEvent event) {
@@ -24,17 +27,8 @@ public class BlockFormListener implements Listener {
             if (island.isPresent()) {
                 IslandUpgrade islandUpgrade = IridiumSkyblock.getInstance().getIslandManager().getIslandUpgrade(island.get(), "generator");
                 OresUpgrade oresUpgrade = IridiumSkyblock.getInstance().getUpgrades().oresUpgrade.upgrades.get(islandUpgrade.getLevel());
-                Map<XMaterial, Integer> ores = newMaterial.equals(XMaterial.BASALT) ? oresUpgrade.netherOres : oresUpgrade.ores;
-                List<XMaterial> materials = new ArrayList<>();
-                Random random = new Random();
-
-                for (Map.Entry<XMaterial, Integer> entries : ores.entrySet()) {
-                    for (int i = 0; i < entries.getValue(); i++) {
-                        materials.add(entries.getKey());
-                    }
-                }
-
-                Material material = materials.get(random.nextInt(materials.size())).parseMaterial();
+                Material[] ores = newMaterial.equals(XMaterial.BASALT) ? oresUpgrade.getNetherOres() : oresUpgrade.getOres();
+                Material material = ores[random.nextInt(ores.length)];
                 if (material != null) event.getNewState().setType(material);
             }
         }

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/SpawnerSpawnListener.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/SpawnerSpawnListener.java
@@ -4,13 +4,22 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.IslandBooster;
 import org.bukkit.Bukkit;
+import org.bukkit.block.CreatureSpawner;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.SpawnerSpawnEvent;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class SpawnerSpawnListener implements Listener {
+
+    /**
+     * Spawners spawn multiple entities per SpawnerSpawnEvent.
+     * This list locks the spawner from getting a smaller delay multiple times per cycle.
+     */
+    private List<CreatureSpawner> lock = new ArrayList<>();
 
     @EventHandler
     public void onCreatureSpawn(SpawnerSpawnEvent event) {
@@ -18,9 +27,14 @@ public class SpawnerSpawnListener implements Listener {
         if (island.isPresent()) {
             IslandBooster islandBooster = IridiumSkyblock.getInstance().getIslandManager().getIslandBooster(island.get(), "spawner");
             if (islandBooster.isActive()) {
+                CreatureSpawner spawner = event.getSpawner();
+                if(lock.contains(spawner))
+                    return;
+                lock.add(spawner);
                 Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> {
-                    event.getSpawner().setDelay(event.getSpawner().getDelay() / 2);
-                    event.getSpawner().update();
+                    spawner.setDelay(event.getSpawner().getDelay() / 2);
+                    spawner.update();
+                    lock.remove(spawner);
                 });
             }
         }

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
@@ -14,17 +14,18 @@ public class OresUpgrade extends UpgradeData {
     private Map<XMaterial, Integer> ores;
     @JsonSerialize
     private Map<XMaterial, Integer> netherOres;
+    @JsonIgnore
+    private Material[] oresArray;
+    @JsonIgnore
+    private Material[] netherOresArray;
+    @JsonIgnore
+    private boolean initialized = false;
 
     public OresUpgrade(int money, int crystals, Map<XMaterial, Integer> ores, Map<XMaterial, Integer> netherOres) {
         super(money, crystals);
         this.ores = ores;
         this.netherOres = netherOres;
     }
-
-    @JsonIgnore
-    private Material[] oresArray;
-    @JsonIgnore
-    private Material[] netherOresArray;
 
     @JsonIgnore
     public Material[] getOres() {
@@ -37,9 +38,6 @@ public class OresUpgrade extends UpgradeData {
         if (!initialized) initialize();
         return netherOresArray;
     }
-
-    @JsonIgnore
-    private boolean initialized = false;
 
     @JsonIgnore
     private void initialize() {

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
@@ -1,18 +1,72 @@
 package com.iridium.iridiumskyblock.upgrades;
 
 import com.cryptomorin.xseries.XMaterial;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.NoArgsConstructor;
+import org.bukkit.Material;
 
 import java.util.Map;
 
 @NoArgsConstructor
 public class OresUpgrade extends UpgradeData {
-    public Map<XMaterial, Integer> ores;
-    public Map<XMaterial, Integer> netherOres;
+    @JsonSerialize
+    private Map<XMaterial, Integer> ores;
+    @JsonSerialize
+    private Map<XMaterial, Integer> netherOres;
 
     public OresUpgrade(int money, int crystals, Map<XMaterial, Integer> ores, Map<XMaterial, Integer> netherOres) {
         super(money, crystals);
         this.ores = ores;
         this.netherOres = netherOres;
+    }
+
+    @JsonIgnore
+    private Material[] oresArray;
+    @JsonIgnore
+    private Material[] netherOresArray;
+
+    @JsonIgnore
+    public Material[] getOres() {
+        if (!initialized) initialize();
+        return oresArray;
+    }
+
+    @JsonIgnore
+    public Material[] getNetherOres() {
+        if (!initialized) initialize();
+        return netherOresArray;
+    }
+
+    @JsonIgnore
+    private boolean initialized = false;
+
+    @JsonIgnore
+    private void initialize() {
+        int arraySize = 0;
+        for (Map.Entry<XMaterial, Integer> entries : ores.entrySet()) {
+            arraySize += entries.getValue();
+        }
+        this.oresArray = new Material[arraySize];
+        int index = 0;
+        for (Map.Entry<XMaterial, Integer> entries : ores.entrySet()) {
+            Material m = entries.getKey().parseMaterial();
+            for (int i = 0; i < entries.getValue(); i++) {
+                this.oresArray[index++] = m;
+            }
+        }
+
+        int arraySizeNether = 0;
+        for (Map.Entry<XMaterial, Integer> entries : netherOres.entrySet()) {
+            arraySizeNether += entries.getValue();
+        }
+        this.netherOresArray = new Material[arraySizeNether];
+        int indexNether = 0;
+        for (Map.Entry<XMaterial, Integer> entries : netherOres.entrySet()) {
+            Material m = entries.getKey().parseMaterial();
+            for (int i = 0; i < entries.getValue(); i++) {
+                this.netherOresArray[indexNether++] = m;
+            }
+        }
     }
 }

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/upgrades/OresUpgrade.java
@@ -41,30 +41,31 @@ public class OresUpgrade extends UpgradeData {
 
     @JsonIgnore
     private void initialize() {
-        int arraySize = 0;
+        int oreFrequencySum = 0;
         for (Map.Entry<XMaterial, Integer> entries : ores.entrySet()) {
-            arraySize += entries.getValue();
+            oreFrequencySum += entries.getValue();
         }
-        this.oresArray = new Material[arraySize];
+        this.oresArray = new Material[oreFrequencySum];
         int index = 0;
         for (Map.Entry<XMaterial, Integer> entries : ores.entrySet()) {
-            Material m = entries.getKey().parseMaterial();
+            Material material = entries.getKey().parseMaterial();
             for (int i = 0; i < entries.getValue(); i++) {
-                this.oresArray[index++] = m;
+                this.oresArray[index++] = material;
             }
         }
 
-        int arraySizeNether = 0;
+        int netherOreFrequencySum = 0;
         for (Map.Entry<XMaterial, Integer> entries : netherOres.entrySet()) {
-            arraySizeNether += entries.getValue();
+            netherOreFrequencySum += entries.getValue();
         }
-        this.netherOresArray = new Material[arraySizeNether];
+        this.netherOresArray = new Material[netherOreFrequencySum];
         int indexNether = 0;
         for (Map.Entry<XMaterial, Integer> entries : netherOres.entrySet()) {
-            Material m = entries.getKey().parseMaterial();
+            Material material = entries.getKey().parseMaterial();
             for (int i = 0; i < entries.getValue(); i++) {
-                this.netherOresArray[indexNether++] = m;
+                this.netherOresArray[indexNether++] = material;
             }
         }
+        initialized = true;
     }
 }


### PR DESCRIPTION
Creating a new ArrayList and filling it with loads of objects, as well as parsing a lot of materials on each BlockFormEvent is going to cause significant lag. This changes the system to parse the rarities of ores once, and reuse the parsed data.