### PR TITLE
Replace reflection for multi-version support with safe alternative

### DIFF
--- a/multiversion/v1_10_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_10_R1.java
+++ b/multiversion/v1_10_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_10_R1.java
@@ -7,7 +7,7 @@ import org.bukkit.Material;
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_11_R1 implements MultiVersion {
+public class MultiVersion_V1_10_R1 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.

--- a/multiversion/v1_10_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_10_R1.java
+++ b/multiversion/v1_10_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_10_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_16_R1.*;
+import net.minecraft.server.v1_10_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_16_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_10_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_16_R1.
+ * This is the implementation for V1_10_R1.
  */
-public class V1_16_R1 implements NMS {
+public class NMS_V1_10_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -39,12 +39,11 @@ public class V1_16_R1 implements NMS {
 
         ChunkSection chunkSection = nmsChunk.getSections()[y >> 4];
         if (chunkSection == null) {
-            chunkSection = new ChunkSection(y >> 4 << 4);
+            chunkSection = new ChunkSection(y >> 4 << 4, true);
             nmsChunk.getSections()[y >> 4] = chunkSection;
         }
 
         chunkSection.setType(x & 15, y & 15, z & 15, ibd);
-        nmsChunk.getWorld().getChunkProvider().getLightEngine().a(new BlockPosition(x, y, z));
     }
 
     /**
@@ -56,7 +55,7 @@ public class V1_16_R1 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535, true);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );
@@ -91,6 +90,7 @@ public class V1_16_R1 implements NMS {
         } else if (color == Color.GREEN) {
             worldBorder.transitionSizeBetween(size - 0.1D, size, 20000000L);
         }
+
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(new PacketPlayOutWorldBorder(worldBorder, PacketPlayOutWorldBorder.EnumWorldBorderAction.INITIALIZE));
     }
 

--- a/multiversion/v1_11_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_11_R1.java
+++ b/multiversion/v1_11_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_11_R1.java
@@ -7,7 +7,7 @@ import org.bukkit.Material;
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_9_R2 implements MultiVersion {
+public class MultiVersion_V1_11_R1 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.

--- a/multiversion/v1_11_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_11_R1.java
+++ b/multiversion/v1_11_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_11_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_13_R1.*;
+import net.minecraft.server.v1_11_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_13_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_13_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_13_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_11_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_13_R1.
+ * This is the implementation for V1_11_R1.
  */
-public class V1_13_R1 implements NMS {
+public class NMS_V1_11_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_12_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_12_R1.java
+++ b/multiversion/v1_12_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_12_R1.java
@@ -2,12 +2,11 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.Material;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_8_R2 implements MultiVersion {
+public class MultiVersion_V1_12_R1 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.
@@ -19,9 +18,8 @@ public class V1_8_R2 implements MultiVersion {
      * @return The material at the provided position in the chunk
      */
     @Override
-    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
+        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
     }
 
 }

--- a/multiversion/v1_12_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_12_R1.java
+++ b/multiversion/v1_12_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_12_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_13_R2.*;
+import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_13_R2.CraftChunk;
-import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_12_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_13_R2.
+ * This is the implementation for V1_12_R1.
  */
-public class V1_13_R2 implements NMS {
+public class NMS_V1_12_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_13_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_13_R1.java
+++ b/multiversion/v1_13_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_13_R1.java
@@ -2,26 +2,30 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_13_R1.util.CraftLegacy;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_10_R1 implements MultiVersion {
+public class MultiVersion_V1_13_R1 implements MultiVersion {
+
+    @SuppressWarnings("deprecation")
+    public MultiVersion_V1_13_R1() {
+        new CraftLegacy();
+    }
 
     /**
      * Returns the material at a position in a chunk.
      *
      * @param chunk The snapshot of the chunk where the position is in
-     * @param x The relative x position of the block in the chunk
-     * @param y The relative y position of the block in the chunk
-     * @param z The relative z position of the block in the chunk
+     * @param x     The relative x position of the block in the chunk
+     * @param y     The relative y position of the block in the chunk
+     * @param z     The relative z position of the block in the chunk
      * @return The material at the provided position in the chunk
      */
     @Override
-    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
+        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
     }
 
 }

--- a/multiversion/v1_13_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_13_R1.java
+++ b/multiversion/v1_13_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_13_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_8_R3.*;
+import net.minecraft.server.v1_13_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
-import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_13_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_13_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_13_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_8_R3.
+ * This is the implementation for V1_13_R1.
  */
-public class V1_8_R3 implements NMS {
+public class NMS_V1_13_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -55,7 +55,7 @@ public class V1_8_R3 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), true, 65535);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );

--- a/multiversion/v1_13_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_13_R2.java
+++ b/multiversion/v1_13_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_13_R2.java
@@ -7,10 +7,10 @@ import org.bukkit.craftbukkit.v1_13_R2.util.CraftLegacy;
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_13_R2 implements MultiVersion {
+public class MultiVersion_V1_13_R2 implements MultiVersion {
 
     @SuppressWarnings("deprecation")
-    public V1_13_R2() {
+    public MultiVersion_V1_13_R2() {
         new CraftLegacy();
     }
 

--- a/multiversion/v1_13_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_13_R2.java
+++ b/multiversion/v1_13_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_13_R2.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_11_R1.*;
+import net.minecraft.server.v1_13_R2.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_11_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_13_R2.CraftChunk;
+import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_11_R1.
+ * This is the implementation for V1_13_R2.
  */
-public class V1_11_R1 implements NMS {
+public class NMS_V1_13_R2 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_14_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_14_R1.java
+++ b/multiversion/v1_14_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_14_R1.java
@@ -2,12 +2,17 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_14_R1.util.CraftLegacy;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_9_R1 implements MultiVersion {
+public class MultiVersion_V1_14_R1 implements MultiVersion {
+
+    @SuppressWarnings("deprecation")
+    public MultiVersion_V1_14_R1(){
+        new CraftLegacy();
+    }
 
     /**
      * Returns the material at a position in a chunk.
@@ -19,9 +24,8 @@ public class V1_9_R1 implements MultiVersion {
      * @return The material at the provided position in the chunk
      */
     @Override
-    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
+        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
     }
 
 }

--- a/multiversion/v1_14_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_14_R1.java
+++ b/multiversion/v1_14_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_14_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_8_R2.*;
+import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_8_R2.CraftChunk;
-import org.bukkit.craftbukkit.v1_8_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R2.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_14_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_8_R2.
+ * This is the implementation for V1_14_R1.
  */
-public class V1_8_R2 implements NMS {
+public class NMS_V1_14_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -39,11 +39,12 @@ public class V1_8_R2 implements NMS {
 
         ChunkSection chunkSection = nmsChunk.getSections()[y >> 4];
         if (chunkSection == null) {
-            chunkSection = new ChunkSection(y >> 4 << 4, true);
+            chunkSection = new ChunkSection(y >> 4 << 4);
             nmsChunk.getSections()[y >> 4] = chunkSection;
         }
 
         chunkSection.setType(x & 15, y & 15, z & 15, ibd);
+        nmsChunk.getWorld().getChunkProvider().getLightEngine().a(new BlockPosition(x, y, z));
     }
 
     /**
@@ -55,7 +56,7 @@ public class V1_8_R2 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), true, 65535);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );

--- a/multiversion/v1_15_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_15_R1.java
+++ b/multiversion/v1_15_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_15_R1.java
@@ -2,25 +2,25 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.craftbukkit.v1_13_R1.util.CraftLegacy;
+import org.bukkit.craftbukkit.v1_15_R1.legacy.CraftLegacy;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_13_R1 implements MultiVersion {
+public class MultiVersion_V1_15_R1 implements MultiVersion {
 
     @SuppressWarnings("deprecation")
-    public V1_13_R1() {
-        new CraftLegacy();
+    public MultiVersion_V1_15_R1(){
+        CraftLegacy.init();
     }
 
     /**
      * Returns the material at a position in a chunk.
      *
      * @param chunk The snapshot of the chunk where the position is in
-     * @param x     The relative x position of the block in the chunk
-     * @param y     The relative y position of the block in the chunk
-     * @param z     The relative z position of the block in the chunk
+     * @param x The relative x position of the block in the chunk
+     * @param y The relative y position of the block in the chunk
+     * @param z The relative z position of the block in the chunk
      * @return The material at the provided position in the chunk
      */
     @Override

--- a/multiversion/v1_15_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_15_R1.java
+++ b/multiversion/v1_15_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_15_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_16_R2.*;
+import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_16_R2.CraftChunk;
-import org.bukkit.craftbukkit.v1_16_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_15_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for v1_16_R2.
+ * This is the implementation for V1_15_R1.
  */
-public class V1_16_R2 implements NMS {
+public class NMS_V1_15_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_16_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R1.java
+++ b/multiversion/v1_16_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R1.java
@@ -7,10 +7,10 @@ import org.bukkit.craftbukkit.v1_16_R1.legacy.CraftLegacy;
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_16_R1 implements MultiVersion {
+public class MultiVersion_V1_16_R1 implements MultiVersion {
 
     @SuppressWarnings("deprecation")
-    public V1_16_R1(){
+    public MultiVersion_V1_16_R1(){
         CraftLegacy.init();
     }
 

--- a/multiversion/v1_16_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R1.java
+++ b/multiversion/v1_16_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R1.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_15_R1.*;
+import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_15_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_16_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_15_R1.
+ * This is the implementation for V1_16_R1.
  */
-public class V1_15_R1 implements NMS {
+public class NMS_V1_16_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -56,7 +56,7 @@ public class V1_15_R1 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535, true);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );
@@ -91,7 +91,6 @@ public class V1_15_R1 implements NMS {
         } else if (color == Color.GREEN) {
             worldBorder.transitionSizeBetween(size - 0.1D, size, 20000000L);
         }
-
         ((CraftPlayer) player).getHandle().playerConnection.sendPacket(new PacketPlayOutWorldBorder(worldBorder, PacketPlayOutWorldBorder.EnumWorldBorderAction.INITIALIZE));
     }
 

--- a/multiversion/v1_16_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R2.java
+++ b/multiversion/v1_16_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R2.java
@@ -2,15 +2,15 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.craftbukkit.v1_15_R1.legacy.CraftLegacy;
+import org.bukkit.craftbukkit.v1_16_R2.legacy.CraftLegacy;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_15_R1 implements MultiVersion {
+public class MultiVersion_V1_16_R2 implements MultiVersion {
 
     @SuppressWarnings("deprecation")
-    public V1_15_R1(){
+    public MultiVersion_V1_16_R2(){
         CraftLegacy.init();
     }
 

--- a/multiversion/v1_16_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R2.java
+++ b/multiversion/v1_16_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R2.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_12_R1.*;
+import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_12_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_16_R2.CraftChunk;
+import org.bukkit.craftbukkit.v1_16_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_12_R1.
+ * This is the implementation for v1_16_R2.
  */
-public class V1_12_R1 implements NMS {
+public class NMS_V1_16_R2 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -39,11 +39,12 @@ public class V1_12_R1 implements NMS {
 
         ChunkSection chunkSection = nmsChunk.getSections()[y >> 4];
         if (chunkSection == null) {
-            chunkSection = new ChunkSection(y >> 4 << 4, true);
+            chunkSection = new ChunkSection(y >> 4 << 4);
             nmsChunk.getSections()[y >> 4] = chunkSection;
         }
 
         chunkSection.setType(x & 15, y & 15, z & 15, ibd);
+        nmsChunk.getWorld().getChunkProvider().getLightEngine().a(new BlockPosition(x, y, z));
     }
 
     /**

--- a/multiversion/v1_16_R3/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R3.java
+++ b/multiversion/v1_16_R3/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_16_R3.java
@@ -2,15 +2,12 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.craftbukkit.v1_16_R2.legacy.CraftLegacy;
+import org.bukkit.craftbukkit.v1_16_R3.legacy.CraftLegacy;
 
-/**
- * Interface for working with methods that were changed during an update by Spigot.
- */
-public class V1_16_R2 implements MultiVersion {
+public class MultiVersion_V1_16_R3 implements MultiVersion {
 
     @SuppressWarnings("deprecation")
-    public V1_16_R2(){
+    public MultiVersion_V1_16_R3(){
         CraftLegacy.init();
     }
 

--- a/multiversion/v1_16_R3/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R3.java
+++ b/multiversion/v1_16_R3/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_16_R3.java
@@ -16,7 +16,7 @@ import java.util.List;
  * Version-specific, so it has to be implemented for every version we support.
  * This is the implementation for v1_16_R3.
  */
-public class V1_16_R3 implements NMS {
+public class NMS_V1_16_R3 implements NMS {
 
   /**
    * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_8_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_8_R2.java
+++ b/multiversion/v1_8_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_8_R2.java
@@ -2,17 +2,12 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.craftbukkit.v1_14_R1.util.CraftLegacy;
+import org.bukkit.Material;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_14_R1 implements MultiVersion {
-
-    @SuppressWarnings("deprecation")
-    public V1_14_R1(){
-        new CraftLegacy();
-    }
+public class MultiVersion_V1_8_R2 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.
@@ -24,8 +19,9 @@ public class V1_14_R1 implements MultiVersion {
      * @return The material at the provided position in the chunk
      */
     @Override
+    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
+        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
     }
 
 }

--- a/multiversion/v1_8_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_8_R2.java
+++ b/multiversion/v1_8_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_8_R2.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_9_R2.*;
+import net.minecraft.server.v1_8_R2.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_9_R2.CraftChunk;
-import org.bukkit.craftbukkit.v1_9_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_9_R2.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R2.CraftChunk;
+import org.bukkit.craftbukkit.v1_8_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_9_R2.
+ * This is the implementation for V1_8_R2.
  */
-public class V1_9_R2 implements NMS {
+public class NMS_V1_8_R2 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -55,7 +55,7 @@ public class V1_9_R2 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), true, 65535);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );

--- a/multiversion/v1_8_R3/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_8_R3.java
+++ b/multiversion/v1_8_R3/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_8_R3.java
@@ -2,14 +2,12 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
-import org.bukkit.craftbukkit.v1_16_R3.legacy.CraftLegacy;
+import org.bukkit.Material;
 
-public class V1_16_R3 implements MultiVersion {
-
-    @SuppressWarnings("deprecation")
-    public V1_16_R3(){
-        CraftLegacy.init();
-    }
+/**
+ * Interface for working with methods that were changed during an update by Spigot.
+ */
+public class MultiVersion_V1_8_R3 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.
@@ -21,8 +19,9 @@ public class V1_16_R3 implements MultiVersion {
      * @return The material at the provided position in the chunk
      */
     @Override
+    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
+        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
     }
 
 }

--- a/multiversion/v1_8_R3/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_8_R3.java
+++ b/multiversion/v1_8_R3/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_8_R3.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_10_R1.*;
+import net.minecraft.server.v1_8_R3.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_10_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_10_R1.
+ * This is the implementation for V1_8_R3.
  */
-public class V1_10_R1 implements NMS {
+public class NMS_V1_8_R3 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -55,7 +55,7 @@ public class V1_10_R1 implements NMS {
      */
     @Override
     public void sendChunk(List<Player> players, org.bukkit.Chunk chunk) {
-        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), 65535);
+        PacketPlayOutMapChunk packetPlayOutMapChunk = new PacketPlayOutMapChunk(((CraftChunk) chunk).getHandle(), true, 65535);
         players.forEach(player ->
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packetPlayOutMapChunk)
         );

--- a/multiversion/v1_9_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_9_R1.java
+++ b/multiversion/v1_9_R1/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_9_R1.java
@@ -7,7 +7,7 @@ import org.bukkit.Material;
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_8_R2 implements MultiVersion {
+public class MultiVersion_V1_9_R1 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.

--- a/multiversion/v1_9_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_9_R1.java
+++ b/multiversion/v1_9_R1/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_9_R1.java
@@ -16,7 +16,7 @@ import java.util.List;
  * Version-specific, so it has to be implemented for every version we support.
  * This is the implementation for V1_9_R1.
  */
-public class V1_9_R1 implements NMS {
+public class NMS_V1_9_R1 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.

--- a/multiversion/v1_9_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_9_R2.java
+++ b/multiversion/v1_9_R2/src/main/java/com/iridium/iridiumskyblock/multiversion/MultiVersion_V1_9_R2.java
@@ -2,11 +2,12 @@ package com.iridium.iridiumskyblock.multiversion;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.ChunkSnapshot;
+import org.bukkit.Material;
 
 /**
  * Interface for working with methods that were changed during an update by Spigot.
  */
-public class V1_12_R1 implements MultiVersion {
+public class MultiVersion_V1_9_R2 implements MultiVersion {
 
     /**
      * Returns the material at a position in a chunk.
@@ -18,8 +19,9 @@ public class V1_12_R1 implements MultiVersion {
      * @return The material at the provided position in the chunk
      */
     @Override
+    @SuppressWarnings("deprecation")
     public XMaterial getMaterialAtPosition(ChunkSnapshot chunk, int x, int y, int z) {
-        return XMaterial.matchXMaterial(chunk.getBlockType(x, y, z));
+        return XMaterial.matchXMaterial(Material.getMaterial(chunk.getBlockTypeId(x, y, z)));
     }
 
 }

--- a/multiversion/v1_9_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_9_R2.java
+++ b/multiversion/v1_9_R2/src/main/java/com/iridium/iridiumskyblock/nms/NMS_V1_9_R2.java
@@ -1,12 +1,12 @@
 package com.iridium.iridiumskyblock.nms;
 
 import com.iridium.iridiumskyblock.Color;
-import net.minecraft.server.v1_14_R1.*;
+import net.minecraft.server.v1_9_R2.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_14_R1.CraftChunk;
-import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_9_R2.CraftChunk;
+import org.bukkit.craftbukkit.v1_9_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_9_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -14,9 +14,9 @@ import java.util.List;
 /**
  * Interface for working with the net.minecraft.server package.
  * Version-specific, so it has to be implemented for every version we support.
- * This is the implementation for V1_14_R1.
+ * This is the implementation for V1_9_R2.
  */
-public class V1_14_R1 implements NMS {
+public class NMS_V1_9_R2 implements NMS {
 
     /**
      * Sets blocks faster than with Spigots implementation.
@@ -39,12 +39,11 @@ public class V1_14_R1 implements NMS {
 
         ChunkSection chunkSection = nmsChunk.getSections()[y >> 4];
         if (chunkSection == null) {
-            chunkSection = new ChunkSection(y >> 4 << 4);
+            chunkSection = new ChunkSection(y >> 4 << 4, true);
             nmsChunk.getSections()[y >> 4] = chunkSection;
         }
 
         chunkSection.setType(x & 15, y & 15, z & 15, ibd);
-        nmsChunk.getWorld().getChunkProvider().getLightEngine().a(new BlockPosition(x, y, z));
     }
 
     /**

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/Persist.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/Persist.java
@@ -204,6 +204,7 @@ public class Persist {
         try {
             return objectMapper.readValue(content, clazz);
         } catch (IOException e) {
+            e.printStackTrace();
             Bukkit.getPluginManager().disablePlugin(javaPlugin);
         }
 

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
@@ -624,7 +624,7 @@ public class IslandManager {
                                     if (island.isInIsland(x + (chunk.getX() * 16), z + (chunk.getZ() * 16))) {
                                         final int maxy = Math.min(maxHeight, chunk.getHighestBlockYAt(x, z));
                                         for (int y = 0; y <= maxy; y++) {
-                                            XMaterial material = IridiumSkyblock.getInstance().getMultiversion().getMaterialAtPosition(chunk, x, y, z);
+                                            XMaterial material = IridiumSkyblock.getInstance().getMultiVersion().getMaterialAtPosition(chunk, x, y, z);
                                             if (material.equals(XMaterial.AIR)) continue;
 
                                             IslandBlocks IslandBlocks = IridiumSkyblock.getInstance().getIslandManager().getIslandBlock(island, material);

--- a/plugin/src/main/java/com/iridium/iridiumskyblock/multiversion/MinecraftVersion.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/multiversion/MinecraftVersion.java
@@ -1,0 +1,63 @@
+package com.iridium.iridiumskyblock.multiversion;
+
+import com.iridium.iridiumskyblock.nms.NMS;
+import com.iridium.iridiumskyblock.nms.NMS_V1_10_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_11_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_12_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_13_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_13_R2;
+import com.iridium.iridiumskyblock.nms.NMS_V1_14_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_15_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_16_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_16_R2;
+import com.iridium.iridiumskyblock.nms.NMS_V1_16_R3;
+import com.iridium.iridiumskyblock.nms.NMS_V1_8_R2;
+import com.iridium.iridiumskyblock.nms.NMS_V1_8_R3;
+import com.iridium.iridiumskyblock.nms.NMS_V1_9_R1;
+import com.iridium.iridiumskyblock.nms.NMS_V1_9_R2;
+import java.util.function.Supplier;
+
+public enum MinecraftVersion {
+
+    V1_8_R2(NMS_V1_8_R2::new, MultiVersion_V1_8_R2::new),
+    V1_8_R3(NMS_V1_8_R3::new, MultiVersion_V1_8_R3::new),
+    V1_9_R1(NMS_V1_9_R1::new, MultiVersion_V1_9_R1::new),
+    V1_9_R2(NMS_V1_9_R2::new, MultiVersion_V1_9_R2::new),
+    V1_10_R1(NMS_V1_10_R1::new, MultiVersion_V1_10_R1::new),
+    V1_11_R1(NMS_V1_11_R1::new, MultiVersion_V1_11_R1::new),
+    V1_12_R1(NMS_V1_12_R1::new, MultiVersion_V1_12_R1::new),
+    V1_13_R1(NMS_V1_13_R1::new, MultiVersion_V1_13_R1::new),
+    V1_13_R2(NMS_V1_13_R2::new, MultiVersion_V1_13_R2::new),
+    V1_14_R1(NMS_V1_14_R1::new, MultiVersion_V1_14_R1::new),
+    V1_15_R1(NMS_V1_15_R1::new, MultiVersion_V1_15_R1::new),
+    V1_16_R1(NMS_V1_16_R1::new, MultiVersion_V1_16_R1::new),
+    V1_16_R2(NMS_V1_16_R2::new, MultiVersion_V1_16_R2::new),
+    V1_16_R3(NMS_V1_16_R3::new, MultiVersion_V1_16_R3::new);
+
+    private final Supplier<NMS> nmsSupplier;
+    private final Supplier<MultiVersion> multiVersionSupplier;
+
+    MinecraftVersion(Supplier<NMS> nmsSupplier, Supplier<MultiVersion> multiVersionSupplier) {
+        this.nmsSupplier = nmsSupplier;
+        this.multiVersionSupplier = multiVersionSupplier;
+    }
+
+    public NMS getNms() {
+        return nmsSupplier.get();
+    }
+
+    public MultiVersion getMultiVersion() {
+        return multiVersionSupplier.get();
+    }
+
+    public static MinecraftVersion byName(String version) {
+        for (MinecraftVersion minecraftVersion : values()) {
+            if (minecraftVersion.name().equalsIgnoreCase(version)) {
+                return minecraftVersion;
+            }
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
Uses an enum instead of reflections to access the multi-version support and fixes an issue with the V1_8_R3 multi-version class having a wrong name