### PR TITLE
Fix item pickup event for legacy versions

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/EntityPickupItemListener.java
+++ b/plugin/src/main/java/com/iridium/iridiumskyblock/listeners/EntityPickupItemListener.java
@@ -2,23 +2,18 @@ package com.iridium.iridiumskyblock.listeners;
 
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.database.Island;
-import org.bukkit.entity.EntityType;
+import java.util.Optional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityPickupItemEvent;
-
-import java.util.Optional;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 
 public class EntityPickupItemListener implements Listener {
 
     @EventHandler
-    public void onEntityPickupItem(EntityPickupItemEvent event) {
-        if (event.getEntityType() != EntityType.PLAYER) {
-            return;
-        }
-
-        Player player = (Player) event.getEntity();
+    @SuppressWarnings("deprecation")
+    public void onEntityPickupItem(PlayerPickupItemEvent event) {
+        Player player = event.getPlayer();
         Optional<Island> island = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getItem().getLocation());
         if (!island.isPresent()) return;
 


### PR DESCRIPTION
On old Minecraft versions like 1.8, the EntityItemPickupEvent does not exist. Therefore we have to use the PlayerItemPickupEvent instead which is, unfortunately, deprecated but should still work.