### PR TITLE
Fix islandrewards not being saved on databases with a too small default column width

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/database/IslandReward.java
+++ b/src/main/java/com/iridium/iridiumskyblock/database/IslandReward.java
@@ -22,7 +22,7 @@ public final class IslandReward extends IslandData {
     @DatabaseField(columnName = "id", generatedId = true, canBeNull = false)
     private int id;
 
-    @DatabaseField(columnName = "reward", canBeNull = false)
+    @DatabaseField(columnName = "reward", canBeNull = false, width = 2048)
     private @NotNull String reward;
 
     /**


### PR DESCRIPTION
Raised column width default to 2048 to accomodate for more data. This data includes reward item lores and reward commands which can be added by a user through config. Therefore this limit can still be reached, but the user will have to change the limit in their database themself if they reach it.
closes #164 