### PR TITLE
Add Obsidian -> Lava Bucket

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
@@ -36,6 +36,7 @@ public class Configuration {
     public boolean netherIslands = true;
     public boolean endIslands = true;
     public boolean respawnOnIsland = true;
+    public boolean obsidianBucket = true;
 
     public int distance = 151;
     public int schematicPastingDelay = 1;
@@ -50,7 +51,7 @@ public class Configuration {
 
     public GeneratorSettings generatorSettings = new GeneratorSettings();
 
-    public Map<Integer, Integer> islandTopSlots = ImmutableMap.<Integer, Integer>builder()
+    public Map<Integer, Integer> islandTopSlots = ImmutableMap.<Integer, Integer> builder()
             .put(1, 4)
             .put(2, 12)
             .put(3, 14)
@@ -63,7 +64,7 @@ public class Configuration {
             .put(10, 25)
             .build();
 
-    public Map<Integer, Integer> islandWarpSlots = ImmutableMap.<Integer, Integer>builder()
+    public Map<Integer, Integer> islandWarpSlots = ImmutableMap.<Integer, Integer> builder()
             .put(1, 9)
             .put(2, 11)
             .put(3, 13)
@@ -79,7 +80,7 @@ public class Configuration {
      * e.g. 1 will give the reward to every level since every number is divisible by 1
      * 5 will give the reward to levels 5 10 15 20 25 ect since they are divisible by 5
      */
-    public Map<Integer, Reward> islandLevelRewards = ImmutableMap.<Integer, Reward>builder()
+    public Map<Integer, Reward> islandLevelRewards = ImmutableMap.<Integer, Reward> builder()
             .put(1, new Reward(new Item(XMaterial.EXPERIENCE_BOTTLE, 1, "&b&lLevel %island_level% Reward", Arrays.asList(
                     "&7Island Level %island_level% Rewards:",
                     "&b&l* &b5 Island Crystals",

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
@@ -5,12 +5,19 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.PermissionType;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
+import com.iridium.iridiumskyblock.managers.IslandManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
@@ -31,13 +38,54 @@ public class BucketListener implements Listener {
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         Optional<Island> island = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getBlockClicked().getLocation());
 
-        if (!island.isPresent()) return;
+        if (!island.isPresent())
+            return;
         if (IridiumSkyblock.getInstance().getIslandManager().getIslandPermission(island.get(), user, PermissionType.BUCKET)) {
             return;
         }
 
         event.setCancelled(true);
         player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().cannotUseBuckets.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
+    }
+
+    @EventHandler
+    public void onClick(PlayerInteractEvent event) {
+        // I tested this on 1.17.1 so if it doesnt work on any version lower, they can suck it kekW
+
+        final Block clickedBlock = event.getClickedBlock();
+        if (clickedBlock == null)
+            return;
+
+        if (event.getHand() != EquipmentSlot.HAND)
+            return;
+
+        final ItemStack handItem = event.getItem();
+        if (handItem == null)
+            return;
+
+        if (handItem.getType() != Material.BUCKET)
+            return;
+
+        if (clickedBlock.getType() != Material.OBSIDIAN)
+            return;
+
+        final IslandManager manager = IridiumSkyblock.getInstance().getIslandManager();
+
+        final Optional<Island> islandOptional = manager.getIslandViaLocation(event.getClickedBlock().getLocation());
+        if (!islandOptional.isPresent())
+            return;
+
+        final User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
+
+        if (!manager.getIslandPermission(islandOptional.get(), user, PermissionType.BUCKET))
+            return;
+
+
+        event.getClickedBlock().setType(Material.AIR);
+        // Change item in hand a ticket later to prevent lava duplication
+        Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () -> event.getPlayer().getInventory().setItem(event.getHand(), new ItemStack(Material.LAVA_BUCKET)), 1);
+
+        event.setCancelled(true);
     }
 
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
@@ -80,10 +80,10 @@ public class BucketListener implements Listener {
         if (!manager.getIslandPermission(islandOptional.get(), user, PermissionType.BUCKET))
             return;
 
-
+        handItem.setAmount(handItem.getAmount() - 1);
         event.getClickedBlock().setType(Material.AIR);
         // Change item in hand a tick later to prevent lava duplication
-        Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () -> event.getPlayer().getInventory().setItem(event.getHand(), new ItemStack(Material.LAVA_BUCKET)), 1);
+        Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () -> event.getPlayer().getInventory().addItem(new ItemStack(Material.LAVA_BUCKET)), 1);
 
         event.setCancelled(true);
     }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
@@ -82,7 +82,7 @@ public class BucketListener implements Listener {
 
 
         event.getClickedBlock().setType(Material.AIR);
-        // Change item in hand a ticket later to prevent lava duplication
+        // Change item in hand a tick later to prevent lava duplication
         Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () -> event.getPlayer().getInventory().setItem(event.getHand(), new ItemStack(Material.LAVA_BUCKET)), 1);
 
         event.setCancelled(true);

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BucketListener.java
@@ -3,6 +3,7 @@ package com.iridium.iridiumskyblock.listeners;
 import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.PermissionType;
+import com.iridium.iridiumskyblock.configs.Configuration;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
 import com.iridium.iridiumskyblock.managers.IslandManager;
@@ -67,6 +68,12 @@ public class BucketListener implements Listener {
             return;
 
         if (clickedBlock.getType() != Material.OBSIDIAN)
+            return;
+
+        if (!IridiumSkyblock.getInstance().getConfiguration().obsidianBucket)
+            return;
+
+        if (event.getPlayer().isSneaking())
             return;
 
         final IslandManager manager = IridiumSkyblock.getInstance().getIslandManager();


### PR DESCRIPTION
This is a useful feature for those absolute degenerates that dont know how to make a cobble gen, who doesnt know how to make a cobblegen in 2021? anyway lets not bully those bakas anymore.

It can be used to covert obsidian back into lava whenever they do mess up some how. I wrote this for 1.17 so it likely isnt that backwards compatible but whatever, Suck it old verisons