### PR TITLE
Added UserJoinEvent and missing `@Getter` in some other events

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/api/IslandCreateEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/IslandCreateEvent.java
@@ -35,7 +35,7 @@ public class IslandCreateEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/IslandDeleteEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/IslandDeleteEvent.java
@@ -36,7 +36,7 @@ public class IslandDeleteEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/IslandRegenEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/IslandRegenEvent.java
@@ -39,7 +39,7 @@ public class IslandRegenEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserChatToggleEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserChatToggleEvent.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class UserChatToggleEvent extends Event implements Cancellable {
-
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private final boolean newChatState;

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserDemoteEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserDemoteEvent.java
@@ -39,7 +39,7 @@ public class UserDemoteEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
@@ -9,8 +9,6 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 @Getter
 public class UserJoinEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
@@ -23,6 +21,10 @@ public class UserJoinEvent extends Event implements Cancellable {
         this.island = island;
         this.user = user;
         this.inviter = inviter;
+    }
+
+    public boolean isJoinedByInvite() {
+        return inviter != null;
     }
 
     @NotNull

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
@@ -25,11 +25,6 @@ public class UserJoinEvent extends Event implements Cancellable {
         this.inviter = inviter;
     }
 
-    // make that Optional because the `inviter` can be null
-    public Optional<User> getInviter() {
-        return Optional.ofNullable(inviter);
-    }
-
     @NotNull
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
@@ -7,17 +7,27 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 @Getter
-public class UserLeaveEvent extends Event implements Cancellable {
+public class UserJoinEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private final Island island;
     private final User user;
+    private final User inviter;
 
-    public UserLeaveEvent(Island island, User user) {
+    public UserJoinEvent(Island island, User user, @Nullable User inviter) {
         this.island = island;
         this.user = user;
+        this.inviter = inviter;
+    }
+
+    // make that Optional because the `inviter` can be null
+    public Optional<User> getInviter() {
+        return Optional.ofNullable(inviter);
     }
 
     @NotNull

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserJoinEvent.java
@@ -43,7 +43,7 @@ public class UserJoinEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserKickEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserKickEvent.java
@@ -38,7 +38,7 @@ public class UserKickEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserLeaveEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserLeaveEvent.java
@@ -36,7 +36,7 @@ public class UserLeaveEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/api/UserPromoteEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/UserPromoteEvent.java
@@ -39,7 +39,7 @@ public class UserPromoteEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
@@ -4,6 +4,7 @@ import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.IslandRank;
 import com.iridium.iridiumskyblock.LogAction;
+import com.iridium.iridiumskyblock.api.UserJoinEvent;
 import com.iridium.iridiumskyblock.database.*;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -63,6 +64,12 @@ public class JoinCommand extends Command {
                         player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().islandMemberLimitReached.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                         return false;
                     }
+
+                    // PR: added UserJoinEvent
+                    Optional<User> inviter = islandInvite.map(IslandInvite::getInviter);
+                    UserJoinEvent userJoinEvent = new UserJoinEvent(island.get(), user, inviter.orElse(null));
+                    Bukkit.getPluginManager().callEvent(userJoinEvent);
+                    if(userJoinEvent.isCancelled()) return false;
 
                     // Send a message to all other members
                     for (User member : island.get().getMembers()) {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
@@ -68,7 +68,7 @@ public class JoinCommand extends Command {
                     Optional<User> inviter = islandInvite.map(IslandInvite::getInviter);
                     UserJoinEvent userJoinEvent = new UserJoinEvent(island.get(), user, inviter.orElse(null));
                     Bukkit.getPluginManager().callEvent(userJoinEvent);
-                    if (userJoinEvent.isCancelled()) return false;
+                    if (userJoinEvent.isCancelled()) return true;
 
                     // Send a message to all other members
                     for (User member : island.get().getMembers()) {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
@@ -65,11 +65,10 @@ public class JoinCommand extends Command {
                         return false;
                     }
 
-                    // PR: added UserJoinEvent
                     Optional<User> inviter = islandInvite.map(IslandInvite::getInviter);
                     UserJoinEvent userJoinEvent = new UserJoinEvent(island.get(), user, inviter.orElse(null));
                     Bukkit.getPluginManager().callEvent(userJoinEvent);
-                    if(userJoinEvent.isCancelled()) return false;
+                    if (userJoinEvent.isCancelled()) return false;
 
                     // Send a message to all other members
                     for (User member : island.get().getMembers()) {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/JoinCommand.java
@@ -68,7 +68,7 @@ public class JoinCommand extends Command {
                     Optional<User> inviter = islandInvite.map(IslandInvite::getInviter);
                     UserJoinEvent userJoinEvent = new UserJoinEvent(island.get(), user, inviter.orElse(null));
                     Bukkit.getPluginManager().callEvent(userJoinEvent);
-                    if (userJoinEvent.isCancelled()) return true;
+                    if (userJoinEvent.isCancelled()) return false;
 
                     // Send a message to all other members
                     for (User member : island.get().getMembers()) {


### PR DESCRIPTION
I add missing and useful `UserJoinEvent` in the public API and made that calling in the `JoinCommand`.
Also the `UserLeaveEvent` has not a `@Getter` annotation above the class declaration, it also was fixed.
(sorry for any mistakes, it's my first PR here)