### PR TITLE
Bump ormlite-jdbc & jetbrains-annotations, Chance dependency format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,30 +22,30 @@ repositories {
 
 dependencies {
     // Dependencies that we want to shade in
-    implementation("org.jetbrains", "annotations", "16.0.1")
-    implementation("com.iridium", "IridiumCore", "1.2.3")
-    implementation("org.bstats", "bstats-bukkit", "2.2.1")
-    implementation("com.github.j256", "ormlite-core", "master-SNAPSHOT")
-    implementation("com.j256.ormlite", "ormlite-jdbc", "5.3")
-    implementation("de.jeff_media", "SpigotUpdateChecker", "1.2.4")
+    implementation("org.jetbrains:annotations:21.0.1")
+    implementation("com.iridium:IridiumCore:1.2.3")
+    implementation("org.bstats:bstats-bukkit:2.2.1")
+    implementation("com.github.j256:ormlite-core:master-SNAPSHOT")
+    implementation("com.j256.ormlite:ormlite-jdbc:5.6")
+    implementation("de.jeff_media:SpigotUpdateChecker:1.2.4")
 
     // Other dependencies that are not required or already available at runtime
-    compileOnly("org.projectlombok", "lombok", "1.18.20")
-    compileOnly("org.spigotmc", "spigot-api", "1.17-R0.1-SNAPSHOT")
-    compileOnly("net.ess3", "EssentialsXSpawn", "2.16.1")
-    compileOnly("com.github.MilkBowl", "VaultAPI", "1.7")
-    compileOnly("me.clip", "placeholderapi", "2.9.2")
-    compileOnly("be.maximvdw", "MVdWPlaceholderAPI", "2.1.1-SNAPSHOT") {
+    compileOnly("org.projectlombok:lombok:1.18.20")
+    compileOnly("org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT")
+    compileOnly("net.ess3:EssentialsXSpawn:2.16.1")
+    compileOnly("com.github.MilkBowl:VaultAPI:1.7")
+    compileOnly("me.clip:placeholderapi:2.9.2")
+    compileOnly("be.maximvdw:MVdWPlaceholderAPI:2.1.1-SNAPSHOT") {
         exclude("org.spigotmc")
     }
-    compileOnly("com.gc", "AdvancedSpawners", "1.2.6")
-    compileOnly("dev.rosewood", "rosestacker", "1.2.6")
-    compileOnly("com.github.OmerBenGera", "WildStackerAPI", "master")
-    compileOnly("com.songoda", "UltimateStacker", "2.1.6")
-    compileOnly("com.songoda", "EpicSpawners", "7.1")
+    compileOnly("com.gc:AdvancedSpawners:1.2.6")
+    compileOnly("dev.rosewood:rosestacker:1.2.6")
+    compileOnly("com.github.OmerBenGera:WildStackerAPI:master")
+    compileOnly("com.songoda:UltimateStacker:2.1.6")
+    compileOnly("com.songoda:EpicSpawners:7.1")
 
     // Enable lombok annotation processing
-    annotationProcessor("org.projectlombok", "lombok", "1.18.20")
+    annotationProcessor("org.projectlombok:lombok:1.18.20")
 }
 
 tasks {


### PR DESCRIPTION
This will update these two dependencies and will switch back to the old dependency format because it's the only supported one for the new dependency manager of IntelliJ IDEA 2021.2