### PR TITLE
Anti-Island Member Kick

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
@@ -44,9 +44,11 @@ public class PrivateCommand extends Command {
             island.get().setVisitable(false);
             int visitorCount = 0;
             List<IslandTrusted> islandTrusted = IridiumSkyblock.getInstance().getDatabaseManager().getIslandTrustedTableManager().getEntries(island.get());
+            final List<User> islandMembers = island.get().getMembers();
+
             for (User visitor : IridiumSkyblock.getInstance().getIslandManager().getPlayersOnIsland(island.get())) {
 
-                if (island.get().getMembers().contains(visitor))
+                if (islandMembers.contains(visitor))
                     continue;
 
                 if (visitor.getIsland().map(Island::getId).orElse(0) == island.get().getId() || islandTrusted.stream().anyMatch(trustedIsland -> trustedIsland.getUser().getUuid() == visitor.getUuid())) {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
@@ -45,6 +45,10 @@ public class PrivateCommand extends Command {
             int visitorCount = 0;
             List<IslandTrusted> islandTrusted = IridiumSkyblock.getInstance().getDatabaseManager().getIslandTrustedTableManager().getEntries(island.get());
             for (User visitor : IridiumSkyblock.getInstance().getIslandManager().getPlayersOnIsland(island.get())) {
+
+                if (island.get().getMembers().contains(visitor))
+                    continue;
+
                 if (visitor.getIsland().map(Island::getId).orElse(0) == island.get().getId() || islandTrusted.stream().anyMatch(trustedIsland -> trustedIsland.getUser().getUuid() == visitor.getUuid())) {
                     continue;
                 }


### PR DESCRIPTION
The plugin will no longer kick island members and send them back to spawn when the island is set to private