### PR TITLE
Make portals are works when nether or end islands disabled

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -224,7 +224,7 @@ public class IridiumSkyblock extends IridiumCore {
     }
 
     /**
-     * Automatically resets the Island missions in a defined time intervall.
+     * Automatically resets the Island missions in a defined time interval.
      */
     private void resetIslandMissions() {
         Calendar c = Calendar.getInstance();

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -10,7 +10,6 @@ import com.iridium.iridiumskyblock.managers.IslandManager;
 import com.iridium.iridiumskyblock.utils.PlayerUtils;
 import java.util.Objects;
 import java.util.Optional;
-import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -3,71 +3,62 @@ package com.iridium.iridiumskyblock.listeners;
 import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.PermissionType;
+import com.iridium.iridiumskyblock.api.IridiumSkyblockAPI;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
 import com.iridium.iridiumskyblock.managers.IslandManager;
-import com.iridium.iridiumskyblock.utils.LocationUtils;
 import com.iridium.iridiumskyblock.utils.PlayerUtils;
+import java.util.Objects;
+import java.util.Optional;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
-import java.util.Objects;
-import java.util.Optional;
-
 public class PlayerPortalListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerPortal(PlayerPortalEvent event) {
+        World fromWorld = event.getFrom().getWorld();
+
+        if (!IridiumSkyblockAPI.getInstance().isIslandWorld(fromWorld)) return;
+
         IslandManager islandManager = IridiumSkyblock.getInstance().getIslandManager();
+        Optional<Island> island = islandManager.getIslandViaLocation(event.getFrom());
+        User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
 
-        final Optional<Island> island = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getFrom());
-        if (!island.isPresent())
-            return;
-
-        final User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
-        if (!IridiumSkyblock.getInstance().getIslandManager().getIslandPermission(island.get(), user, PermissionType.PORTAL)) {
+        if (island.isPresent() && !IridiumSkyblock.getInstance().getIslandManager().getIslandPermission(island.get(), user, PermissionType.PORTAL)) {
             event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().cannotUsePortal.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
             event.setCancelled(true);
 
-            // Teleport them back to the island to prevent constant chat spam.
-            if (event.getCause() == PlayerTeleportEvent.TeleportCause.END_PORTAL) {
-
-                if (island.get().isVisitable() || user.getIsland().map(Island::getId).orElse(0) == island.get().getId()) {
-                    event.getPlayer().teleport(island.get().getHome());
-                } else {
-                    PlayerUtils.teleportSpawn(event.getPlayer());
-                }
-
+            if (island.get().isVisitable() || user.getIsland().map(Island::getId).orElse(0) == island.get().getId()) {
+                event.getPlayer().teleport(island.get().getHome());
+            } else {
+                PlayerUtils.teleportSpawn(event.getPlayer());
             }
-            return;
-        }
 
-        if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
-            if (IridiumSkyblock.getInstance().getConfiguration().netherIslands) {
-                World world = Objects.equals(event.getFrom().getWorld(), islandManager.getNetherWorld()) ? islandManager.getWorld() : islandManager.getNetherWorld();
+        } else if (event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL && IridiumSkyblock.getInstance().getConfiguration().netherIslands) {
+
+            if (island.isPresent()) {
+                World world = Objects.equals(fromWorld, islandManager.getNetherWorld()) ? islandManager.getWorld() : islandManager.getNetherWorld();
                 event.setTo(island.get().getCenter(world));
-                return;
+            } else {
+                event.setCancelled(true);
             }
 
-            event.setCancelled(true);
-            event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().netherIslandsDisabled.replace("%prefix", IridiumSkyblock.getInstance().getConfiguration().prefix)));
-            return;
-        }
+        } else if (event.getCause().equals(PlayerTeleportEvent.TeleportCause.END_PORTAL) && IridiumSkyblock.getInstance().getConfiguration().endIslands) {
 
-        if (event.getCause().equals(PlayerTeleportEvent.TeleportCause.END_PORTAL)) {
-            event.setCancelled(true);
-
-            if (IridiumSkyblock.getInstance().getConfiguration().endIslands) {
-                World world = Objects.equals(event.getFrom().getWorld(), islandManager.getEndWorld()) ? islandManager.getWorld() : islandManager.getEndWorld();
-                event.getPlayer().teleport(LocationUtils.getSafeLocation(island.get().getCenter(world), island.get()));
-                return;
+            if (island.isPresent()) {
+                World world = Objects.equals(fromWorld, islandManager.getEndWorld()) ? islandManager.getWorld() : islandManager.getEndWorld();
+                event.setTo(island.get().getCenter(world));
+            } else {
+                event.setCancelled(true);
             }
 
-            event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().endIslandsDisabled.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
         }
     }
 
 }
+


### PR DESCRIPTION
Wont teleport if nether or end island is enabled but the portal is on a island world and island not present
