### PR TITLE
Optimization: Cache WorldEdit schematic

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -17,6 +17,7 @@ import com.iridium.iridiumskyblock.managers.SchematicManager;
 import com.iridium.iridiumskyblock.managers.UserManager;
 import com.iridium.iridiumskyblock.placeholders.ClipPlaceholderAPI;
 import com.iridium.iridiumskyblock.placeholders.MVDWPlaceholderAPI;
+import com.iridium.iridiumskyblock.schematics.WorldEdit;
 import com.iridium.iridiumskyblock.shop.ShopManager;
 import com.iridium.iridiumskyblock.support.*;
 import com.iridium.iridiumskyblock.utils.PlayerUtils;
@@ -484,6 +485,8 @@ public class IridiumSkyblock extends IridiumCore {
             shopManager.reloadCategories();
         if (commandManager != null)
             commandManager.reloadCommands();
+
+        WorldEdit.clearClipBoardCache();
 
         IridiumSkyblockReloadEvent reloadEvent = new IridiumSkyblockReloadEvent();
         Bukkit.getPluginManager().callEvent(reloadEvent);

--- a/src/main/java/com/iridium/iridiumskyblock/schematics/WorldEdit.java
+++ b/src/main/java/com/iridium/iridiumskyblock/schematics/WorldEdit.java
@@ -16,12 +16,16 @@ import org.bukkit.Location;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.HashMap;
 
 public class WorldEdit implements SchematicPaster {
+
+    private static final HashMap<File, ClipboardFormat> cachedClipboardFormat = new HashMap<>();
+
     @Override
     public void paste(File file, Location location) {
         try {
-            ClipboardFormat format = ClipboardFormats.findByFile(file);
+            ClipboardFormat format = (cachedClipboardFormat.get(file) != null) ? cachedClipboardFormat.get(file) : ClipboardFormats.findByFile(file);
             ClipboardReader reader = format.getReader(new FileInputStream(file));
             Clipboard clipboard = reader.read();
             int width = clipboard.getDimensions().getBlockX();
@@ -37,9 +41,14 @@ public class WorldEdit implements SchematicPaster {
                         .ignoreAirBlocks(true)
                         .build();
                 Operations.complete(operation);
+                cachedClipboardFormat.putIfAbsent(file, format);
             }
         } catch (IOException | WorldEditException e) {
             e.printStackTrace();
         }
+    }
+
+    public static void clearClipBoardCache() {
+        cachedClipboardFormat.clear();
     }
 }


### PR DESCRIPTION
Test on Windows 11 x64 : 
Java 16.0.1
Purpur 1.17.1 build 1400
WorldEdit 7.2.6 (No FAWE, No AWE)
I9-9900K (4 vcpu)

Without cache : 30 ms and 17 tps and 4 sec for teleport player
With cache :
- first paste : 30 ms / 17 tps / 4 sec for teleport player
- after : 10 ms / 20 tps and ~1 sec for teleport player