### PR TITLE
Configuration for Metrics and Check Version

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -202,10 +202,8 @@ public class IridiumSkyblock extends IridiumCore {
 
         resetIslandMissions();
 
-        if (getConfiguration().enableMetrics) {
-            Metrics metrics = new Metrics(this, 5825);
-            metrics.addCustomChart(new SimplePie("database_type", () -> sql.driver.name()));
-        }
+        Metrics metrics = new Metrics(this, 5825);
+        metrics.addCustomChart(new SimplePie("database_type", () -> sql.driver.name()));
 
         if (getConfiguration().enableCheckVersion) {
             UpdateChecker.init(this, 62480)

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
@@ -26,7 +26,6 @@ public class Configuration {
 
     public String prefix = "<GRADIENT:09C6F9>&lIridiumSkyblock</GRADIENT:045DE9> &8»";
     public String worldName = "IridiumSkyblock";
-    public boolean enableMetrics = true;
     public boolean enableCheckVersion = true;
     public String islandCreateTitle = "&b&lIsland Created";
     public String islandCreateSubTitle = "&7IridiumSkyblock by Peaches_MLG";


### PR DESCRIPTION
Allows to deactivate the Metrics and the version check which can cause problems if the firewall prohibits the connection (spam console)