### PR TITLE
Remove Ori from the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug, unconfirmed
-assignees: PeachesMLG, dlsf, Oribuin, MertUnverdi
+assignees: PeachesMLG, dlsf, MertUnverdi
 
 ---
 


### PR DESCRIPTION
Why was he even added? 