### PR TITLE
Remove unnecessary API initialization method

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -172,9 +172,6 @@ public class IridiumSkyblock extends IridiumCore {
         this.shopManager = new ShopManager();
         shopManager.reloadCategories();
 
-        // Initialize the API
-        IridiumSkyblockAPI.initializeAPI(this);
-
         this.schematicManager = new SchematicManager();
 
         // Initialize Vault economy support

--- a/src/main/java/com/iridium/iridiumskyblock/api/IridiumSkyblockAPI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/IridiumSkyblockAPI.java
@@ -28,6 +28,10 @@ public class IridiumSkyblockAPI {
     private static IridiumSkyblockAPI instance;
     private final IridiumSkyblock iridiumSkyblock;
 
+    static {
+        instance = new IridiumSkyblockAPI(IridiumSkyblock.getInstance());
+    }
+
     /**
      * Constructor for api initialization.
      *
@@ -46,17 +50,6 @@ public class IridiumSkyblockAPI {
      */
     public static IridiumSkyblockAPI getInstance() {
         return instance;
-    }
-
-    /**
-     * Initializes the api. For internal use only.
-     *
-     * @param iridiumSkyblock The {@link IridiumSkyblock} instance used by the plugin
-     */
-    public static synchronized void initializeAPI(IridiumSkyblock iridiumSkyblock) {
-        if (instance == null) {
-            instance = new IridiumSkyblockAPI(iridiumSkyblock);
-        }
     }
 
     /**


### PR DESCRIPTION
That method was added to support dependency injection, but since we're staying with singletons, this solution looks better in my opinion.