### PR TITLE
Fix Crystal Item Place

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -59,6 +59,7 @@ public class PlayerInteractListener implements Listener {
                                 .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
                                 .replace("%type%", IridiumSkyblock.getInstance().getBankItems().crystalsBankItem.getDisplayName())
                                 .replace("%amount%", String.valueOf(islandCrystals))));
+                        event.setCancelled(true);
                     }
                 }
             }


### PR DESCRIPTION
Disables the possibility to place the crystal item if it is set to a block, like player head.