### PR TITLE
Fix explosions being able to happen on foreign islands

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/EntityExplodeListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/EntityExplodeListener.java
@@ -21,7 +21,14 @@ public class EntityExplodeListener implements Listener {
             IslandSetting tntExplosion = IridiumSkyblock.getInstance().getIslandManager().getIslandSetting(island, SettingType.TNT_DAMAGE);
             if (!tntExplosion.getBooleanValue()) {
                 event.setCancelled(true);
+                return;
             }
+
+            if (!island.isInIsland(event.getLocation())) {
+                event.setCancelled(true);
+                return;
+            }
+
             event.blockList().removeIf(block -> !island.isInIsland(block.getLocation()));
         });
     }


### PR DESCRIPTION
Fixes #584, TNT can still damage on islands where it hasn't been ignited at