### PR TITLE
Add weight to the mission slots

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -287,9 +287,9 @@ public class IridiumSkyblock extends IridiumCore {
             @Override
             public void run() {
                 databaseManager.getIslandMissionTableManager().delete(
-                        databaseManager.getIslandMissionTableManager().getEntries().stream().filter(islandMission ->
-                                islandMission.getType() == Mission.MissionType.DAILY).collect(Collectors.toList()
-                        )
+                        databaseManager.getIslandMissionTableManager().getEntries().stream()
+                                .filter(islandMission -> islandMission.getType() == Mission.MissionType.DAILY)
+                                .collect(Collectors.toList())
                 );
                 Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> resetIslandMissions());
             }

--- a/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
@@ -812,7 +812,7 @@ public class IslandManager {
         IntStream.range(0, IridiumSkyblock.getInstance().getMissions().dailySlots.size())
                 .boxed()
                 .map(i -> getDailyIslandMission(island, i))
-                .sorted(Comparator.comparingInt(mission -> IridiumSkyblock.getInstance().getMissionsList().get(mission).getItem().slot).reversed())
+                .sorted(Comparator.comparingInt(mission -> IridiumSkyblock.getInstance().getMissionsList().get(mission).getItem().slot))
                 .forEachOrdered(mission ->
                         missions.put(mission, IridiumSkyblock.getInstance().getMissionsList().get(mission))
                 );

--- a/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
@@ -807,12 +807,13 @@ public class IslandManager {
      * @return The daily missions
      */
     public synchronized Map<String, Mission> getDailyIslandMissions(@NotNull Island island) {
-        Map<String, Mission> missions = new HashMap<>();
+        Map<String, Mission> missions = new LinkedHashMap<>();
 
         IntStream.range(0, IridiumSkyblock.getInstance().getMissions().dailySlots.size())
                 .boxed()
                 .map(i -> getDailyIslandMission(island, i))
-                .forEach(mission ->
+                .sorted(Comparator.comparingInt(mission -> IridiumSkyblock.getInstance().getMissionsList().get(mission).getItem().slot).reversed())
+                .forEachOrdered(mission ->
                         missions.put(mission, IridiumSkyblock.getInstance().getMissionsList().get(mission))
                 );
 


### PR DESCRIPTION
**How this works**
When you configure a mission, you can now set the slot to numbers other than 0. This will determine the weight of this mission. The selection is still random, but the missions that have been selected will be ordered according to their weight, starting with the lowest slot. This will allow users to prevent missions from switching slots when they don't want them to.