### PR TITLE
Fix Exploit Teleportation

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -15,21 +15,32 @@ public class PlayerTeleportListener implements Listener {
     public void onPlayerTeleport(PlayerTeleportEvent event) {
         if (event.getTo() == null) return;
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
-        IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getTo()).ifPresent(island -> {
-                    if (IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {
-                        event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
-                                .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
-                                .replace("%owner%", island.getOwner().getName())
-                                .replace("%name%", island.getName())
-                        ));
-                        event.setCancelled(true);
-                    } else {
-                        Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () ->
-                                        PlayerUtils.sendBorder(event.getPlayer(), island)
-                                , 1);
-                    }
+        Optional<Island> islandOptional = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getTo());
+        if (islandOptional.isPresent()) {
+            Island island = islandOptional.get();
+            if (!event.getPlayer().hasPermission("iridiumskyblock.bypassban") && IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {
+                event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
+                        .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
+                        .replace("%owner%", island.getOwner().getName())
+                        .replace("%name%", island.getName())
+                ));
+                event.setCancelled(true);
+            } else {
+                if (island.isVisitable() || (user.isBypassing() || island.getMembers().contains(user) || island.getOwner().equals(user))) {
+                    Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () ->
+                                    PlayerUtils.sendBorder(event.getPlayer(), island)
+                            , 1);
+                } else {
+                    event.setCancelled(true);
+                    event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().islandIsPrivate
+                            .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                 }
-        );
+            }
+        } else {
+            event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noIslandFound
+                    .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
+            if (!event.getPlayer().hasPermission("iridiumskyblock.locationisland.bypass")) event.setCancelled(true); // Unsafe Teleportation
+        }
     }
 
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -19,6 +19,7 @@ public class PlayerTeleportListener implements Listener {
         if (event.getTo() == null) return;
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
         Optional<Island> islandOptional = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getTo());
+        
         if (islandOptional.isPresent()) {
             Island island = islandOptional.get();
             if (!event.getPlayer().hasPermission("iridiumskyblock.bypassban") && IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -6,6 +6,7 @@ import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
 import com.iridium.iridiumskyblock.utils.PlayerUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
@@ -17,13 +18,14 @@ public class PlayerTeleportListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPlayerTeleport(PlayerTeleportEvent event) {
         if (event.getTo() == null) return;
-        User user = IridiumSkyblock.getInstance().getUserManager().getUser(event.getPlayer());
+        Player player = event.getPlayer();
+        User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         Optional<Island> islandOptional = IridiumSkyblock.getInstance().getIslandManager().getIslandViaLocation(event.getTo());
         
         if (islandOptional.isPresent()) {
             Island island = islandOptional.get();
-            if (!event.getPlayer().hasPermission("iridiumskyblock.bypassban") && IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {
-                event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
+            if (!player.hasPermission("iridiumskyblock.bypassban") && IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {
+                player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
                         .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
                         .replace("%owner%", island.getOwner().getName())
                         .replace("%name%", island.getName())
@@ -33,19 +35,19 @@ public class PlayerTeleportListener implements Listener {
             } else {
                 if (island.isVisitable() || (user.isBypassing() || island.getMembers().contains(user) || island.getOwner().equals(user))) {
                     Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () ->
-                                    PlayerUtils.sendBorder(event.getPlayer(), island)
+                                    PlayerUtils.sendBorder(player, island)
                             , 1);
                 } else {
                     event.setCancelled(true);
-                    event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().islandIsPrivate
+                    player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().islandIsPrivate
                             .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                 }
             }
         } else {
-            event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noIslandFound
+            player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noIslandFound
                     .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                     
-            if (!event.getPlayer().hasPermission("iridiumskyblock.locationisland.bypass")) event.setCancelled(true); // Unsafe Teleportation
+            if (!player.hasPermission("iridiumskyblock.locationisland.bypass")) event.setCancelled(true); // Unsafe Teleportation
         }
     }
 

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -2,6 +2,7 @@ package com.iridium.iridiumskyblock.listeners;
 
 import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiumskyblock.IridiumSkyblock;
+import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
 import com.iridium.iridiumskyblock.utils.PlayerUtils;
 import org.bukkit.Bukkit;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -44,6 +44,7 @@ public class PlayerTeleportListener implements Listener {
         } else {
             event.getPlayer().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noIslandFound
                     .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
+                    
             if (!event.getPlayer().hasPermission("iridiumskyblock.locationisland.bypass")) event.setCancelled(true); // Unsafe Teleportation
         }
     }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -25,13 +25,14 @@ public class PlayerTeleportListener implements Listener {
         if (islandOptional.isPresent()) {
             Island island = islandOptional.get();
             if (!player.hasPermission("iridiumskyblock.bypassban") && IridiumSkyblock.getInstance().getIslandManager().isBannedOnIsland(island, user)) {
-                player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
-                        .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
-                        .replace("%owner%", island.getOwner().getName())
-                        .replace("%name%", island.getName())
-                ));
-                
-                event.setCancelled(true);
+                if (!user.isBypassing()) {
+                    player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().youHaveBeenBanned
+                            .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
+                            .replace("%owner%", island.getOwner().getName())
+                            .replace("%name%", island.getName())
+                    ));
+                    event.setCancelled(true);
+                }
             } else {
                 if (island.isVisitable() || (user.isBypassing() || island.getMembers().contains(user) || island.getOwner().equals(user))) {
                     Bukkit.getScheduler().runTaskLater(IridiumSkyblock.getInstance(), () ->

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -10,6 +10,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
+import java.util.Optional;
+
 public class PlayerTeleportListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -27,6 +27,7 @@ public class PlayerTeleportListener implements Listener {
                         .replace("%owner%", island.getOwner().getName())
                         .replace("%name%", island.getName())
                 ));
+                
                 event.setCancelled(true);
             } else {
                 if (island.isVisitable() || (user.isBypassing() || island.getMembers().contains(user) || island.getOwner().equals(user))) {


### PR DESCRIPTION
Fixed an exploit that allowed to bypass private is. (Example: /sethome)
Fixed an exploit that allowed traveling between islands when there are none. (Example: /sethome)
Added permission to travel between islands.