### PR TITLE
Fix default schematic offsets

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Schematics.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Schematics.java
@@ -20,7 +20,7 @@ public class Schematics {
 
     public Map<String, SchematicConfig> schematics = ImmutableMap.<String, SchematicConfig>builder()
             .put("desert", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 11, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGY0OTNkZDgwNjUzM2Q5ZDIwZTg0OTUzOTU0MzY1ZjRkMzY5NzA5Y2ViYzlkZGVmMDIyZDFmZDQwZDg2YTY4ZiJ9fX0=", 1, "&b&lDesert Island", Collections.singletonList("&7A starter desert island.")),
-                    -1.5, 95, -0.5, 90, new SchematicWorld(XBiome.DESERT,
+                    1.5, 88, -0.5, 90, new SchematicWorld(XBiome.DESERT,
                     "desert.schem", 90.0, true
             ), new SchematicWorld(XBiome.NETHER_WASTES,
                     "desert_nether.schem", 90.0, true
@@ -28,7 +28,7 @@ public class Schematics {
                     "desert_end.schem", 90.0, true
             )))
             .put("jungle", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 13, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjgzYWRmNDU2MGRlNDc0MTQwNDA5M2FjNjFjMzNmYjU1NmIzZDllZTUxNDBmNjIwMzYyNTg5ZmRkZWRlZmEyZCJ9fX0=", 1, "&b&lJungle Island", Collections.singletonList("&7A starter jungle island.")),
-                    1.5, 95, 0.5, 90, new SchematicWorld(XBiome.JUNGLE,
+                    0.5, 89, 0.5, 0, new SchematicWorld(XBiome.JUNGLE,
                     "jungle.schem", 90.0, true
             ), new SchematicWorld(XBiome.NETHER_WASTES,
                     "jungle_nether.schem", 90.0, true
@@ -36,7 +36,7 @@ public class Schematics {
                     "jungle_end.schem", 90.0, true
             )))
             .put("mushroom", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 15, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWE0NWQxYjQxN2NiZGRjMjE3NjdiMDYwNDRlODk5YjI2NmJmNzhhNjZlMjE4NzZiZTNjMDUxNWFiNTVkNzEifX19", 1, "&b&lMushroom Island", Collections.singletonList("&7A starter mushroom island.")),
-                    -1.5, 95, -0.5, 90, new SchematicWorld(XBiome.MUSHROOM_FIELDS,
+                    1.5, 89, -0.5, 90, new SchematicWorld(XBiome.MUSHROOM_FIELDS,
                     "mushroom.schem", 90.0, true
             ), new SchematicWorld(XBiome.NETHER_WASTES,
                     "mushroom_nether.schem", 90.0, true


### PR DESCRIPTION
Ran the `/is home currentOffset` command for all 9 schematics. The issue is that they all have different offsets, I used the one from the overworld schematic. However, we should probably implement offsets for all three dimensions.

Here is the list I compiled (second one is nether, third one is end), in case we need it for further changes:
```
Desert 1.5 88 -0.5 90
- 0.5 91 0.5 180
- 2.5 88 0.5 90
Jungle 0.5 82 4.5 180
- 0.5 89 0.5 0
- 0.5 90 0.5 180
Mushroom 1.5 89 -0.5 90
- 0.5 91 0.5 180
- 0.5 91 -3.5 0
```