### PR TITLE
Fix is visit with isBypassing

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/gui/VisitGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/VisitGUI.java
@@ -63,7 +63,7 @@ public class VisitGUI extends GUI {
     @Override
     public void onInventoryClick(InventoryClickEvent event) {
         List<Island> islands = IridiumSkyblock.getInstance().getDatabaseManager().getIslandTableManager().getEntries().stream()
-                .filter(Island::isVisitable)
+                .filter(island -> viewer.isBypassing() || island.isVisitable())
                 .collect(Collectors.toList());
         if (event.getSlot() == getInventory().getSize() - 7) {
             if (page > 1) {


### PR DESCRIPTION
Hello! I found a problem with teleportation to islands when using gui /is visit with /is bypass enabled. The problem is that if /is bypass is enabled, it confuses the index of the pressed island and teleports to a completely different island. This PR will probably fix this problem (need to check)