### PR TITLE
Fix top island placeholder

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
@@ -176,10 +176,17 @@ public class Placeholders {
 
     private static Map<String, Placeholder> getIslandTopPlaceholders() {
         HashMap<String, Placeholder> hashmap = new HashMap<>();
-        List<Island> topIslands = IridiumSkyblock.getInstance().getIslandManager().getIslands(IslandManager.SortType.VALUE);
+        
         for (int i = 1; i <= 20; i++) {
-            Optional<Island> island = Optional.ofNullable(topIslands.size() > i ? topIslands.get(i - 1) : null);
-            hashmap.putAll(getIslandPlaceholders("island_top_" + i, player -> island));
+            //To have an effectively final variable
+            final int ci = i;    
+            hashmap.putAll(getIslandPlaceholders("island_top_" + i, player ->
+            {
+                //Remove global caching of the list, no need for a local cache the island manager caches it.
+                List<Island> topIslands = IridiumSkyblock.getInstance().getIslandManager().getIslands(IslandManager.SortType.VALUE);
+                Optional<Island> island = Optional.ofNullable(topIslands.size() > ci ? topIslands.get(ci - 1) : null);
+                return island;
+            }));
         }
         return hashmap;
     }

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
@@ -178,7 +178,7 @@ public class Placeholders {
         HashMap<String, Placeholder> hashmap = new HashMap<>();
         
         for (int i = 1; i <= 20; i++) {
-            //To have an effectively final variable
+            // To have an effectively final variable
             final int ci = i;    
             hashmap.putAll(getIslandPlaceholders("island_top_" + i, player ->
             {

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
@@ -179,7 +179,7 @@ public class Placeholders {
         
         for (int i = 1; i <= 20; i++) {
             // To have an effectively final variable
-            final int ci = i;    
+            final int index = i;    
             hashmap.putAll(getIslandPlaceholders("island_top_" + i, player ->
             {
                 // Island manager caches this

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
@@ -184,7 +184,7 @@ public class Placeholders {
             {
                 // Island manager caches this
                 List<Island> topIslands = IridiumSkyblock.getInstance().getIslandManager().getIslands(IslandManager.SortType.VALUE);
-                Optional<Island> island = Optional.ofNullable(topIslands.size() > ci ? topIslands.get(ci - 1) : null);
+                Optional<Island> island = Optional.ofNullable(topIslands.size() > index ? topIslands.get(index - 1) : null);
                 return island;
             }));
         }

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/Placeholders.java
@@ -182,7 +182,7 @@ public class Placeholders {
             final int ci = i;    
             hashmap.putAll(getIslandPlaceholders("island_top_" + i, player ->
             {
-                //Remove global caching of the list, no need for a local cache the island manager caches it.
+                // Island manager caches this
                 List<Island> topIslands = IridiumSkyblock.getInstance().getIslandManager().getIslands(IslandManager.SortType.VALUE);
                 Optional<Island> island = Optional.ofNullable(topIslands.size() > ci ? topIslands.get(ci - 1) : null);
                 return island;


### PR DESCRIPTION
Fix top island placeholders by disabling the caching that happened during plugin load time and use the caching done by IslandManager. 