### PR TITLE
WorldEdit incompatibility check

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
@@ -30,10 +30,10 @@ public class SchematicManager {
         File parent = new File(IridiumSkyblock.getInstance().getDataFolder(), "schematics");
         SchematicPaster schematicPaster = worldEdit || fawe ? new WorldEdit() : new Schematic();
         
-        if ((worldEdit||fawe) && !WorldEdit.isWorking())
+        if ((worldEdit || fawe) && !WorldEdit.isWorking())
         {
             IridiumSkyblock.getInstance().getLogger().warning("WorldEdit version doesn't support minecraft version, falling back to default integration");
-            schematicPaster=new Schematic();
+            schematicPaster = new Schematic();
         }
 
         this.schematicPaster = schematicPaster;

--- a/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
@@ -28,7 +28,13 @@ public class SchematicManager {
 
     public SchematicManager() {
         File parent = new File(IridiumSkyblock.getInstance().getDataFolder(), "schematics");
-        this.schematicPaster = worldEdit || fawe ? new WorldEdit() : new Schematic();
+        boolean isWorldEditBroken = (worldEdit||fawe)?!WorldEdit.isWorking():false;
+        if (isWorldEditBroken)
+        {
+            IridiumSkyblock.getInstance().getLogger().warning("WorldEdit version doesn't support minecraft version, falling back to default integration");
+        }
+
+        this.schematicPaster = ((worldEdit || fawe)&&!isWorldEditBroken) ? new WorldEdit() : new Schematic();
         this.schematicFiles = new HashMap<>();
         for (File file : parent.listFiles()) {
             schematicFiles.put(file.getName(), file);

--- a/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/SchematicManager.java
@@ -28,13 +28,15 @@ public class SchematicManager {
 
     public SchematicManager() {
         File parent = new File(IridiumSkyblock.getInstance().getDataFolder(), "schematics");
-        boolean isWorldEditBroken = (worldEdit||fawe)?!WorldEdit.isWorking():false;
-        if (isWorldEditBroken)
+        SchematicPaster schematicPaster = worldEdit || fawe ? new WorldEdit() : new Schematic();
+        
+        if ((worldEdit||fawe) && !WorldEdit.isWorking())
         {
             IridiumSkyblock.getInstance().getLogger().warning("WorldEdit version doesn't support minecraft version, falling back to default integration");
+            schematicPaster=new Schematic();
         }
 
-        this.schematicPaster = ((worldEdit || fawe)&&!isWorldEditBroken) ? new WorldEdit() : new Schematic();
+        this.schematicPaster = schematicPaster;
         this.schematicFiles = new HashMap<>();
         for (File file : parent.listFiles()) {
             schematicFiles.put(file.getName(), file);

--- a/src/main/java/com/iridium/iridiumskyblock/schematics/WorldEdit.java
+++ b/src/main/java/com/iridium/iridiumskyblock/schematics/WorldEdit.java
@@ -3,6 +3,8 @@ package com.iridium.iridiumskyblock.schematics;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.extension.platform.Platform;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
@@ -23,6 +25,14 @@ public class WorldEdit implements SchematicPaster {
 
     private static final HashMap<File, ClipboardFormat> cachedClipboardFormat = new HashMap<>();
 
+    public static boolean isWorking()
+    {
+        final Platform platform = com.sk89q.worldedit.WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING);
+        int liveDataVersion = platform.getDataVersion();
+
+        return liveDataVersion != -1;
+    }
+    
     @Override
     public void paste(File file, Location location, Boolean ignoreAirBlock, CompletableFuture<Void> completableFuture) {
         try {


### PR DESCRIPTION
Verify if WorldEdit is incompatible with the current Minecraft version and switch back to default integration with a warning if that is the case. 