### PR TITLE
Updated IridiumTeams version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.iridium"
-version = "4.0.0"
+version = "4.0.1"
 description = "IridiumSkyblock"
 
 repositories {
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.jetbrains:annotations:24.0.1")
     implementation("com.j256.ormlite:ormlite-core:6.1")
     implementation("com.j256.ormlite:ormlite-jdbc:6.1")
-    implementation("com.iridium:IridiumTeams:2.0.0")
+    implementation("com.iridium:IridiumTeams:2.0.3")
 
     // Other dependencies that are not required or already available at runtime
     compileOnly("org.projectlombok:lombok:1.18.26")


### PR DESCRIPTION
Changes List:
- Updated version of IridiumTeams to make IridiumSkybloc compatible with spigot 1.20.