### PR TITLE
Added endPortalPick setting

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
@@ -48,6 +48,7 @@ public class Configuration extends com.iridium.iridiumteams.configs.Configuratio
 
 
     public boolean obsidianBucket = true;
+    public boolean endPortalPick = true;
     public boolean removeIslandBlocksOnDelete = false;
     public int distance = 151;
     public int netherUnlockLevel = 10;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -53,8 +53,7 @@ public class PlayerInteractListener implements Listener {
                 && (event.getAction().equals(Action.LEFT_CLICK_BLOCK) && player.isSneaking())
                 && event.getClickedBlock().getType().equals(Material.END_PORTAL_FRAME)
                 && (itemInHand.getType().name().contains("PICKAXE"))) {
-
-            event.getClickedBlock().getDrops().add(new ItemStack(Material.END_PORTAL_FRAME));
+            
             event.getClickedBlock().breakNaturally();
 
             player.getInventory().addItem(new ItemStack(Material.END_PORTAL_FRAME)).values().forEach(itemStack ->

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -15,18 +15,13 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
-public class    PlayerInteractListener implements Listener {
+public class PlayerInteractListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onClick(PlayerInteractEvent event) {
         Player player = event.getPlayer();
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
-
-        if (!(IridiumSkyblock.getInstance().getConfiguration().obsidianBucket)
-            && !(IridiumSkyblock.getInstance().getConfiguration().endPortalPick)) {
-            return;
-        }
 
         Optional<Island> island = IridiumSkyblock.getInstance().getTeamManager().getTeamViaLocation(event.getClickedBlock().getLocation());
         if (!island.isPresent()) return;
@@ -43,6 +38,7 @@ public class    PlayerInteractListener implements Listener {
                 && itemInHand.getType().equals(Material.BUCKET)) {
 
             event.getClickedBlock().setType(Material.AIR);
+
             if (itemInHand.getAmount() > 1) {
                 itemInHand.setAmount(itemInHand.getAmount() - 1);
                 player.getInventory().addItem(new ItemStack(Material.LAVA_BUCKET)).values().forEach(itemStack ->
@@ -51,25 +47,18 @@ public class    PlayerInteractListener implements Listener {
             } else {
                 itemInHand.setType(Material.LAVA_BUCKET);
             }
-            event.setCancelled(true);
         }
 
         if(IridiumSkyblock.getInstance().getConfiguration().endPortalPick
-                && event.getAction().equals(Action.RIGHT_CLICK_BLOCK)
+                && (event.getAction().equals(Action.LEFT_CLICK_BLOCK) && player.isSneaking())
                 && event.getClickedBlock().getType().equals(Material.END_PORTAL_FRAME)
-                && itemInHand.getType().equals(Material.WOODEN_PICKAXE)) {
+                && (itemInHand.getType().name().contains("PICKAXE"))) {
 
-            event.getClickedBlock().setType(Material.AIR);
-            if (itemInHand.getAmount() > 1) {
-                itemInHand.setAmount(itemInHand.getAmount() - 1);
-                player.getInventory().addItem(new ItemStack(Material.END_PORTAL_FRAME)).values().forEach(itemStack ->
-                        player.getWorld().dropItem(player.getLocation(), itemStack)
-                );
-            } else {
-                itemInHand.setType(Material.END_PORTAL_FRAME);
-            }
-            event.setCancelled(true);
+            event.getClickedBlock().getDrops().add(new ItemStack(Material.END_PORTAL_FRAME));
+            event.getClickedBlock().breakNaturally();
+
+            player.getInventory().addItem(new ItemStack(Material.END_PORTAL_FRAME)).values().forEach(itemStack ->
+                    player.getWorld().dropItem(player.getLocation(), itemStack));
         }
     }
-
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
-public class PlayerInteractListener implements Listener {
+public class    PlayerInteractListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onClick(PlayerInteractEvent event) {
@@ -23,10 +23,8 @@ public class PlayerInteractListener implements Listener {
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
 
-        if (!(IridiumSkyblock.getInstance().getConfiguration().obsidianBucket
-                && event.getAction().equals(Action.RIGHT_CLICK_BLOCK)
-                && event.getClickedBlock().getType().equals(Material.OBSIDIAN)
-                && itemInHand.getType().equals(Material.BUCKET))) {
+        if (!(IridiumSkyblock.getInstance().getConfiguration().obsidianBucket)
+            && !(IridiumSkyblock.getInstance().getConfiguration().endPortalPick)) {
             return;
         }
 
@@ -39,14 +37,38 @@ public class PlayerInteractListener implements Listener {
             return;
         }
 
-        event.getClickedBlock().setType(Material.AIR);
-        if (itemInHand.getAmount() > 1) {
-            itemInHand.setAmount(itemInHand.getAmount() - 1);
-            player.getInventory().addItem(new ItemStack(Material.LAVA_BUCKET)).values().forEach(itemStack ->
-                    player.getWorld().dropItem(player.getLocation(), itemStack)
-            );
-        } else {
-            itemInHand.setType(Material.LAVA_BUCKET);
+        if(IridiumSkyblock.getInstance().getConfiguration().obsidianBucket
+                && event.getAction().equals(Action.RIGHT_CLICK_BLOCK)
+                && event.getClickedBlock().getType().equals(Material.OBSIDIAN)
+                && itemInHand.getType().equals(Material.BUCKET)) {
+
+            event.getClickedBlock().setType(Material.AIR);
+            if (itemInHand.getAmount() > 1) {
+                itemInHand.setAmount(itemInHand.getAmount() - 1);
+                player.getInventory().addItem(new ItemStack(Material.LAVA_BUCKET)).values().forEach(itemStack ->
+                        player.getWorld().dropItem(player.getLocation(), itemStack)
+                );
+            } else {
+                itemInHand.setType(Material.LAVA_BUCKET);
+            }
+            event.setCancelled(true);
+        }
+
+        if(IridiumSkyblock.getInstance().getConfiguration().endPortalPick
+                && event.getAction().equals(Action.RIGHT_CLICK_BLOCK)
+                && event.getClickedBlock().getType().equals(Material.END_PORTAL_FRAME)
+                && itemInHand.getType().equals(Material.WOODEN_PICKAXE)) {
+
+            event.getClickedBlock().setType(Material.AIR);
+            if (itemInHand.getAmount() > 1) {
+                itemInHand.setAmount(itemInHand.getAmount() - 1);
+                player.getInventory().addItem(new ItemStack(Material.END_PORTAL_FRAME)).values().forEach(itemStack ->
+                        player.getWorld().dropItem(player.getLocation(), itemStack)
+                );
+            } else {
+                itemInHand.setType(Material.END_PORTAL_FRAME);
+            }
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
- added endPortalPick configuration setting to allow the end portal frames to be picked up and placed again, as they are indestructable blocks (right click with wooden pickaxe, consumes pickaxe)
- restructured PlayerInteractListener to accommodate multiple listening targets