### PR TITLE
Added regenInventoryClear

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.iridium"
-version = "4.0.4"
+version = "4.0.5"
 description = "IridiumSkyblock"
 
 repositories {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/RegenCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/RegenCommand.java
@@ -51,13 +51,7 @@ public class RegenCommand extends Command<Island, User> {
                         .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
                 )));
 
-        if(IridiumSkyblock.getInstance().getConfiguration().clearInventoryOnRegen) {
-            player.getInventory().clear();
-        }
-
-        if(IridiumSkyblock.getInstance().getConfiguration().clearEnderChestOnRegen) {
-            player.getEnderChest().clear();
-        }
+        IridiumSkyblock.getInstance().getIslandManager().clearTeamInventory(island);
 
         IridiumSkyblock.getInstance().getIslandManager().generateIsland(island, schematicConfig.get()).thenRun(() -> Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> {
             if (IridiumSkyblock.getInstance().getTeamManager().teleport(player, island.getHome(), island)) {

--- a/src/main/java/com/iridium/iridiumskyblock/commands/RegenCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/RegenCommand.java
@@ -51,6 +51,14 @@ public class RegenCommand extends Command<Island, User> {
                         .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
                 )));
 
+        if(IridiumSkyblock.getInstance().getConfiguration().clearInventoryOnRegen) {
+            player.getInventory().clear();
+        }
+
+        if(IridiumSkyblock.getInstance().getConfiguration().clearEnderChestOnRegen) {
+            player.getEnderChest().clear();
+        }
+
         IridiumSkyblock.getInstance().getIslandManager().generateIsland(island, schematicConfig.get()).thenRun(() -> Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> {
             if (IridiumSkyblock.getInstance().getTeamManager().teleport(player, island.getHome(), island)) {
                 player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().teleportingHome

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
@@ -49,6 +49,8 @@ public class Configuration extends com.iridium.iridiumteams.configs.Configuratio
 
     public boolean obsidianBucket = true;
     public boolean removeIslandBlocksOnDelete = false;
+    public boolean clearInventoryOnRegen = false;
+    public boolean clearEnderChestOnRegen = false;
     public int distance = 151;
     public int netherUnlockLevel = 10;
     public int pasterDelayInTick = 1;

--- a/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/managers/IslandManager.java
@@ -205,7 +205,9 @@ public class IslandManager extends TeamManager<Island, User> {
         if (IridiumSkyblock.getInstance().getConfiguration().removeIslandBlocksOnDelete) {
             deleteIslandBlocks(island);
         }
+
         IridiumSkyblock.getInstance().getDatabaseManager().getIslandTableManager().delete(island);
+        IridiumSkyblock.getInstance().getIslandManager().clearTeamInventory(island);
 
         getMembersOnIsland(island).forEach(member -> PlayerUtils.teleportSpawn(member.getPlayer()));
     }
@@ -577,6 +579,19 @@ public class IslandManager extends TeamManager<Island, User> {
                     .replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)
             ));
             blockEvent.setCancelled(true);
+        }
+    }
+
+    public void clearTeamInventory(Island island) {
+
+        if(IridiumSkyblock.getInstance().getConfiguration().clearInventoryOnRegen) {
+            IridiumSkyblock.getInstance().getIslandManager().getMembersOnIsland(island).forEach(member ->
+                    member.getPlayer().getInventory().clear());
+        }
+
+        if(IridiumSkyblock.getInstance().getConfiguration().clearEnderChestOnRegen) {
+            IridiumSkyblock.getInstance().getIslandManager().getMembersOnIsland(island).forEach(member ->
+                    member.getPlayer().getEnderChest().clear());
         }
     }
 


### PR DESCRIPTION
Added the config options clearInventoryOnRegen & clearEnderChestOnRegen to allow servers to clear player inventories when regenerating islands.