### PR TITLE
netherOnlyGenerator

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Configuration.java
@@ -48,6 +48,7 @@ public class Configuration extends com.iridium.iridiumteams.configs.Configuratio
 
 
     public boolean obsidianBucket = true;
+    public boolean netherOnlyGenerator = false;
     public boolean endPortalPick = true;
     public boolean removeIslandBlocksOnDelete = false;
     public boolean clearInventoryOnRegen = false;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
@@ -39,7 +39,7 @@ public class BlockFormListener implements Listener {
             Optional<XMaterial> xMaterialOptional = randomMaterialList.nextElement();
             if (!xMaterialOptional.isPresent()) return;
 
-            if((randomMaterialList == netherOreLevels.get(upgradeLevel)) && (IridiumSkyblock.getInstance().getConfiguration().netherOnlyGenerator) && (!(event.getNewState().getWorld().getEnvironment() == World.Environment.NETHER))) return;
+            if( isBasaltGenerator && IridiumSkyblock.getInstance().getConfiguration().netherOnlyGenerator && event.getNewState().getWorld().getEnvironment() != World.Environment.NETHER) return;
 
             Material material = xMaterialOptional.get().parseMaterial();
             if (material == Material.COBBLESTONE && newMaterial == XMaterial.STONE) material = Material.STONE;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
@@ -32,8 +32,8 @@ public class BlockFormListener implements Listener {
         if (!generatorMaterials.contains(newMaterial)) return;
         IridiumSkyblock.getInstance().getIslandManager().getTeamViaLocation(event.getNewState().getLocation()).ifPresent(island -> {
             int upgradeLevel = IridiumSkyblock.getInstance().getIslandManager().getTeamEnhancement(island, "generator").getLevel();
-
-            RandomAccessList<XMaterial> randomMaterialList = newMaterial == XMaterial.BASALT ? netherOreLevels.get(upgradeLevel) : normalOreLevels.get(upgradeLevel);
+            boolean isBasaltGenerator = newMaterial == XMaterial.BASALT;
+            RandomAccessList<XMaterial> randomMaterialList = isBasaltGenerator ? netherOreLevels.get(upgradeLevel) : normalOreLevels.get(upgradeLevel);
             if (randomMaterialList == null) return;
 
             Optional<XMaterial> xMaterialOptional = randomMaterialList.nextElement();

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
@@ -5,6 +5,7 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.RandomAccessList;
 import com.iridium.iridiumskyblock.enhancements.GeneratorEnhancementData;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFormEvent;
@@ -31,16 +32,18 @@ public class BlockFormListener implements Listener {
         if (!generatorMaterials.contains(newMaterial)) return;
         IridiumSkyblock.getInstance().getIslandManager().getTeamViaLocation(event.getNewState().getLocation()).ifPresent(island -> {
             int upgradeLevel = IridiumSkyblock.getInstance().getIslandManager().getTeamEnhancement(island, "generator").getLevel();
+
             RandomAccessList<XMaterial> randomMaterialList = newMaterial == XMaterial.BASALT ? netherOreLevels.get(upgradeLevel) : normalOreLevels.get(upgradeLevel);
             if (randomMaterialList == null) return;
 
             Optional<XMaterial> xMaterialOptional = randomMaterialList.nextElement();
             if (!xMaterialOptional.isPresent()) return;
 
+            if((randomMaterialList == netherOreLevels.get(upgradeLevel)) && (IridiumSkyblock.getInstance().getConfiguration().netherOnlyGenerator) && (!(event.getNewState().getWorld().getEnvironment() == World.Environment.NETHER))) return;
+
             Material material = xMaterialOptional.get().parseMaterial();
             if (material == Material.COBBLESTONE && newMaterial == XMaterial.STONE) material = Material.STONE;
             if (material != null) event.getNewState().setType(material);
         });
     }
-
 }


### PR DESCRIPTION
added `netherOnlyGenerator` config option and a check to `BlockFormListener` to determine whether to activate the basalt generator in the overworld & end or be nether exclusive