### PR TITLE
Prevent obsidian platform generate in The End

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -141,7 +141,7 @@ public class IridiumSkyblock extends IridiumTeams<Island, User> {
         Bukkit.getPluginManager().registerEvents(new PlayerPortalListener(), this);
         Bukkit.getPluginManager().registerEvents(new PlayerInteractListener(), this);
         Bukkit.getPluginManager().registerEvents(new EntityDamageListener(), this);
-        if(!XMaterial.supports(16)) Bukkit.getPluginManager().registerEvents(new PortalCreateListener(), this);
+        if(!XMaterial.supports(15)) Bukkit.getPluginManager().registerEvents(new PortalCreateListener(), this);
     }
 
     @Override

--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -1,5 +1,6 @@
 package com.iridium.iridiumskyblock;
 
+import com.iridium.iridiumcore.dependencies.xseries.XMaterial;
 import com.iridium.iridiumskyblock.configs.*;
 import com.iridium.iridiumskyblock.database.Island;
 import com.iridium.iridiumskyblock.database.User;
@@ -140,6 +141,7 @@ public class IridiumSkyblock extends IridiumTeams<Island, User> {
         Bukkit.getPluginManager().registerEvents(new PlayerPortalListener(), this);
         Bukkit.getPluginManager().registerEvents(new PlayerInteractListener(), this);
         Bukkit.getPluginManager().registerEvents(new EntityDamageListener(), this);
+        if(!XMaterial.supports(16)) Bukkit.getPluginManager().registerEvents(new PortalCreateListener(), this);
     }
 
     @Override

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Schematics.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Schematics.java
@@ -19,7 +19,7 @@ public class Schematics {
             .put("desert", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 11, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGY0OTNkZDgwNjUzM2Q5ZDIwZTg0OTUzOTU0MzY1ZjRkMzY5NzA5Y2ViYzlkZGVmMDIyZDFmZDQwZDg2YTY4ZiJ9fX0=", 1, "&9&lDesert Island", Arrays.asList("&7A starter desert island.", "", "&9&l[!] &7Costs $1000")),
                     new Schematics.Cost(1000, new HashMap<>()), -0.5, 89, -0.5, 90, new SchematicWorld(Biome.DESERT,
                     "desert.schem", 90.0, true
-            ), new SchematicWorld(Biome.NETHER_WASTES,
+            ), new SchematicWorld(XMaterial.supports(16) ? Biome.NETHER_WASTES : Biome.valueOf("NETHER"),
                     "desert_nether.schem", 90.0, true
             ), new SchematicWorld(Biome.THE_END,
                     "desert_end.schem", 90.0, true
@@ -27,7 +27,7 @@ public class Schematics {
             .put("jungle", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 13, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjgzYWRmNDU2MGRlNDc0MTQwNDA5M2FjNjFjMzNmYjU1NmIzZDllZTUxNDBmNjIwMzYyNTg5ZmRkZWRlZmEyZCJ9fX0=", 1, "&9&lJungle Island", Arrays.asList("&7A starter jungle island.", "", "&9&l[!] &7Costs $1000")),
                     new Schematics.Cost(1000, new HashMap<>()), 1.5, 83, 1.5, 90, new SchematicWorld(Biome.JUNGLE,
                     "jungle.schem", 90.0, true
-            ), new SchematicWorld(Biome.NETHER_WASTES,
+            ), new SchematicWorld(XMaterial.supports(16) ? Biome.NETHER_WASTES : Biome.valueOf("NETHER"),
                     "jungle_nether.schem", 90.0, true
             ), new SchematicWorld(Biome.THE_END,
                     "jungle_end.schem", 90.0, true
@@ -35,7 +35,7 @@ public class Schematics {
             .put("mushroom", new SchematicConfig(new Item(XMaterial.PLAYER_HEAD, 15, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWE0NWQxYjQxN2NiZGRjMjE3NjdiMDYwNDRlODk5YjI2NmJmNzhhNjZlMjE4NzZiZTNjMDUxNWFiNTVkNzEifX19", 1, "&9&lMushroom Island", Arrays.asList("&7A starter mushroom island.", "", "&9&l[!] &7Costs $1000")),
                     new Schematics.Cost(1000, new HashMap<>()), 0.5, 89, -0.5, 90, new SchematicWorld(Biome.MUSHROOM_FIELDS,
                     "mushroom.schem", 90.0, true
-            ), new SchematicWorld(Biome.NETHER_WASTES,
+            ), new SchematicWorld(XMaterial.supports(16) ? Biome.NETHER_WASTES : Biome.valueOf("NETHER"),
                     "mushroom_nether.schem", 90.0, true
             ), new SchematicWorld(Biome.THE_END,
                     "mushroom_end.schem", 90.0, true

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -62,6 +62,7 @@ public class PlayerPortalListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
+                event.setCanCreatePortal(false);
                 event.setTo(location);
             }
         });

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -1,5 +1,6 @@
 package com.iridium.iridiumskyblock.listeners;
 
+import com.iridium.iridiumcore.dependencies.xseries.XMaterial;
 import com.iridium.iridiumcore.utils.StringUtils;
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.utils.LocationUtils;
@@ -63,7 +64,7 @@ public class PlayerPortalListener implements Listener {
                     return;
                 }
                 location.setY(location.getY() + 1);
-                event.setCanCreatePortal(false);
+                if(XMaterial.supports(16)) event.setCanCreatePortal(false);
                 event.setTo(location);
             }
         });

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -64,7 +64,7 @@ public class PlayerPortalListener implements Listener {
                     return;
                 }
                 location.setY(location.getY() + 1);
-                if(XMaterial.supports(16)) event.setCanCreatePortal(false);
+                if(XMaterial.supports(15)) event.setCanCreatePortal(false);
                 event.setTo(location);
             }
         });

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -62,6 +62,7 @@ public class PlayerPortalListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
+                location.setY(location.getY() + 1);
                 event.setCanCreatePortal(false);
                 event.setTo(location);
             }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PortalCreateListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PortalCreateListener.java
@@ -1,0 +1,16 @@
+package com.iridium.iridiumskyblock.listeners;
+
+import com.iridium.iridiumskyblock.api.IridiumSkyblockAPI;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.PortalCreateEvent;
+
+public class PortalCreateListener implements Listener {
+    @EventHandler
+    public void onPortalCreate(PortalCreateEvent event){
+        if (event.getWorld().equals(IridiumSkyblockAPI.getInstance().getEndWorld()) && event.getBlocks().stream().anyMatch(blockState -> blockState.getType().equals(Material.OBSIDIAN))) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Fix #779 
It works well.
Also fixed player not being in the correct location after teleported. (Old behavior players will be teleported inside the block)

![2024-01-07_15 55 06](https://github.com/Iridium-Development/IridiumSkyblock/assets/45266046/8ece0284-3148-4cde-9adc-43f97061af32)


`setCanCreatePortal` may be incompatible with 1.15-, but it seems possible to abandon 1.15-?

![image](https://github.com/Iridium-Development/IridiumSkyblock/assets/45266046/38febe61-2321-4fd2-8304-b5a286b58d14)
