### PR TITLE
you can click the crystal now

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -27,13 +27,12 @@ public class PlayerInteractListener implements Listener {
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
 
+        int crystalAmount = IridiumSkyblock.getInstance().getIslandManager().getIslandCrystals(itemInHand);
         if((event.getAction() == Action.RIGHT_CLICK_AIR
                 || event.getAction() == Action.RIGHT_CLICK_BLOCK)
-                && IridiumSkyblock.getInstance().getIslandManager().getIslandCrystals(itemInHand) > 0) {
+                && crystalAmount > 0) {
 
-            int crystalAmount = IridiumSkyblock.getInstance().getIslandManager().getIslandCrystals(itemInHand);
             if (IridiumSkyblock.getInstance().getCommandManager().executeCommand(event.getPlayer(), IridiumSkyblock.getInstance().getCommands().depositCommand, new String[] {IridiumSkyblock.getInstance().getBankItems().crystalsBankItem.getName(), String.valueOf(crystalAmount)})) {
-                itemInHand.setAmount(0);
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -21,11 +21,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PlayerInteractListener implements Listener {
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onClick(PlayerInteractEvent event) {
         Player player = event.getPlayer();
         User user = IridiumSkyblock.getInstance().getUserManager().getUser(player);
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
+
+        if((event.getAction() == Action.RIGHT_CLICK_AIR
+                || event.getAction() == Action.RIGHT_CLICK_BLOCK)
+                && IridiumSkyblock.getInstance().getIslandManager().getIslandCrystals(itemInHand) > 0) {
+
+            int crystalAmount = IridiumSkyblock.getInstance().getIslandManager().getIslandCrystals(itemInHand);
+            if (IridiumSkyblock.getInstance().getCommandManager().executeCommand(event.getPlayer(), IridiumSkyblock.getInstance().getCommands().depositCommand, new String[] {IridiumSkyblock.getInstance().getBankItems().crystalsBankItem.getName(), String.valueOf(crystalAmount)})) {
+                itemInHand.setAmount(0);
+                event.setCancelled(true);
+                return;
+            }
+        }
 
         Optional<Island> island = IridiumSkyblock.getInstance().getTeamManager().getTeamViaLocation(event.getClickedBlock().getLocation());
         if (!island.isPresent()) return;


### PR DESCRIPTION
- reimplemented click to deposit so that the default lore tooltip actually makes sense
- required removing the ignoreCancelled flag as right clicking in air automatically sets the event as cancelled apparently