### PR TITLE
Remove default title of bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Create a report to help us improve IridiumSkyblock!
-title: "[Bug] "
 labels: ["bug", "unconfirmed"]
 assignees: ["PeachesMLG", "dlsf", "sh0inx"]
 body:


### PR DESCRIPTION
If we don't want feature requests as issues, there's no need to clutter the title with this, especially given there's also a bug label