### PR TITLE
Add major contributors to plugin.yml as authors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ bukkit {
     main = "com.iridium.iridiumskyblock.IridiumSkyblock"
     apiVersion = "1.13"
     author = "Peaches_MLG"
+    authors = listOf("das_", "sh0inx", "SlashRemix", "Faun471")
 
     loadBefore = listOf("Multiverse-Core")
     depend = listOf("Vault")


### PR DESCRIPTION
The order is based on the combined number of commits on GitHub in the three related projects (which includes v3 commits, but part of that was copied into v4).  boiscljo wants to be excluded. We can reorder the list if we want it to focus on v4 contributions.