### PR TITLE
Add SpigotMC URL to plugin.yml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ bukkit {
     apiVersion = "1.13"
     author = "Peaches_MLG"
     authors = listOf("das_", "sh0inx", "SlashRemix", "Faun471")
+    website = "https://www.spigotmc.org/resources/62480"
 
     loadBefore = listOf("Multiverse-Core")
     depend = listOf("Vault")


### PR DESCRIPTION
This appears to be some sort of "convention" to make it easier to update plugins from the /plugins list. I think it makes sense to add the SpigotMC link there