### PR TITLE
 Fixing Placeholder issue #969 - Update IslandPlaceholderBuilder.java

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/IslandPlaceholderBuilder.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/IslandPlaceholderBuilder.java
@@ -23,6 +23,57 @@ import java.util.stream.Collectors;
 public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
 
     private final TemporaryCache<Island, List<Placeholder>> cache = new TemporaryCache<>();
+    
+    // Static list for ALL placeholders except bank items
+    private static final List<Placeholder> STATIC_DEFAULT_PLACEHOLDERS;
+    
+    static {
+        List<Placeholder> placeholders = new ArrayList<>();
+        
+        // Basic island placeholders
+        placeholders.add(new Placeholder("island_name", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_owner", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_description", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_create", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_value", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_experience", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_experienceToLevelUp", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_experienceForNextLevel", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_value_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_experience_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_members_online", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_members_online_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_members_offline", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_members_offline_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_members_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_visitors", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholders.add(new Placeholder("island_visitors_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        
+        // Enhancement placeholders (these are static since enhancements are defined in config)
+        for (Map.Entry<String, Enhancement<?>> enhancement : IridiumSkyblock.getInstance().getEnhancementList().entrySet()) {
+            placeholders.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_active", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholders.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholders.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_hours", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholders.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_minutes", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholders.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_seconds", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        }
+        
+        // Material placeholders (XMaterial values are static)
+        for (XMaterial xMaterial : XMaterial.values()) {
+            placeholders.add(new Placeholder("island_" + xMaterial.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        }
+        
+        // Entity type placeholders (EntityType values are static)
+        for (EntityType entityType : EntityType.values()) {
+            placeholders.add(new Placeholder("island_" + entityType.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        }
+        
+        STATIC_DEFAULT_PLACEHOLDERS = Collections.unmodifiableList(placeholders);
+    }
+
+    // Cache for ONLY bank item placeholders (the problematic ones)
+    private final TemporaryCache<String, List<Placeholder>> bankItemPlaceholdersCache = new TemporaryCache<>();
 
     @Override
     public List<Placeholder> getPlaceholders(Island island) {
@@ -102,55 +153,22 @@ public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
         return IridiumSkyblock.getInstance().getConfiguration().numberFormatter.format(value);
     }
 
-    private List<Placeholder> getDefaultPlaceholders() {
-        List<Placeholder> placeholderList = new ArrayList<>();
-        
-        // Add all basic placeholders with null placeholder values
-        placeholderList.add(new Placeholder("island_name", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_owner", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_description", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_create", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_value", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_experience", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_experienceToLevelUp", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_experienceForNextLevel", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_value_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_experience_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_members_online", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_members_online_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_members_offline", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_members_offline_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_members_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_visitors", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        placeholderList.add(new Placeholder("island_visitors_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-
-        // Add enhancement placeholders with null values
-        for (Map.Entry<String, Enhancement<?>> enhancement : IridiumSkyblock.getInstance().getEnhancementList().entrySet()) {
-            placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_active", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-            placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-            placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_hours", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-            placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_minutes", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-            placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_seconds", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        }
-
-        // Add bank item placeholders dynamically (when called, not during initialization)
-        for (BankItem bankItem : IridiumSkyblock.getInstance().getBankItemList()) {
-            final String bankItemName = bankItem.getName().toLowerCase();
-            placeholderList.add(new Placeholder("island_bank_" + bankItemName, () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        }
-        
-        // Add material placeholders with null values
-        for (XMaterial xMaterial : XMaterial.values()) {
-            placeholderList.add(new Placeholder("island_" + xMaterial.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        }
-        
-        // Add entity type placeholders with null values
-        for (EntityType entityType : EntityType.values()) {
-            placeholderList.add(new Placeholder("island_" + entityType.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
-        }
-        
-        return placeholderList;
+    /**
+     * Gets bank item placeholders dynamically (only these are cached)
+     * These are cached for 30 seconds to balance performance
+     */
+    private List<Placeholder> getBankItemPlaceholders() {
+        return bankItemPlaceholdersCache.get("bank_items", Duration.ofSeconds(30), () -> {
+            List<Placeholder> bankPlaceholders = new ArrayList<>();
+            
+            // Add ONLY bank item placeholders - this was the missing piece!
+            for (BankItem bankItem : IridiumSkyblock.getInstance().getBankItemList()) {
+                final String bankItemName = bankItem.getName().toLowerCase();
+                bankPlaceholders.add(new Placeholder("island_bank_" + bankItemName, () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            }
+            
+            return bankPlaceholders;
+        });
     }
 
     @Override
@@ -158,8 +176,10 @@ public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
         if (optional.isPresent()) {
             return getPlaceholders(optional.get());
         } else {
-            // Generate placeholders dynamically instead of using cached ones
-            return getDefaultPlaceholders();
+            // Combine static placeholders with ONLY the dynamic bank item placeholders
+            List<Placeholder> allPlaceholders = new ArrayList<>(STATIC_DEFAULT_PLACEHOLDERS);
+            allPlaceholders.addAll(getBankItemPlaceholders());
+            return allPlaceholders;
         }
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/IslandPlaceholderBuilder.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/IslandPlaceholderBuilder.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
 
     private final TemporaryCache<Island, List<Placeholder>> cache = new TemporaryCache<>();
-    private final List<Placeholder> defaultPlaceholders = initializeDefaultPlaceholders();
 
     @Override
     public List<Placeholder> getPlaceholders(Island island) {
@@ -103,26 +102,30 @@ public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
         return IridiumSkyblock.getInstance().getConfiguration().numberFormatter.format(value);
     }
 
-    private List<Placeholder> initializeDefaultPlaceholders() {
-        List<Placeholder> placeholderList = new ArrayList<>(Arrays.asList(
-                new Placeholder("island_name", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_owner", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_description", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_create", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_value", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_level", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_experience", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_value_rank", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_experience_rank", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_members_online", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_members_online_count", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_members_offline", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_members_offline_count", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_members_count", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_visitors", IridiumSkyblock.getInstance().getMessages().nullPlaceholder),
-                new Placeholder("island_visitors_amount", IridiumSkyblock.getInstance().getMessages().nullPlaceholder)
-        ));
+    private List<Placeholder> getDefaultPlaceholders() {
+        List<Placeholder> placeholderList = new ArrayList<>();
+        
+        // Add all basic placeholders with null placeholder values
+        placeholderList.add(new Placeholder("island_name", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_owner", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_description", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_create", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_value", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_experience", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_experienceToLevelUp", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_experienceForNextLevel", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_value_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_experience_rank", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_members_online", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_members_online_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_members_offline", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_members_offline_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_members_count", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_visitors", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+        placeholderList.add(new Placeholder("island_visitors_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
 
+        // Add enhancement placeholders with null values
         for (Map.Entry<String, Enhancement<?>> enhancement : IridiumSkyblock.getInstance().getEnhancementList().entrySet()) {
             placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_active", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
             placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_level", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
@@ -131,20 +134,32 @@ public class IslandPlaceholderBuilder implements PlaceholderBuilder<Island> {
             placeholderList.add(new Placeholder("island_enhancement_" + enhancement.getKey() + "_time_seconds", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
         }
 
+        // Add bank item placeholders dynamically (when called, not during initialization)
         for (BankItem bankItem : IridiumSkyblock.getInstance().getBankItemList()) {
-            placeholderList.add(new Placeholder("island_bank_" + bankItem.getName().toLowerCase(), IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            final String bankItemName = bankItem.getName().toLowerCase();
+            placeholderList.add(new Placeholder("island_bank_" + bankItemName, () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
         }
+        
+        // Add material placeholders with null values
         for (XMaterial xMaterial : XMaterial.values()) {
-            placeholderList.add(new Placeholder("island_" + xMaterial.name().toLowerCase() + "_amount", IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholderList.add(new Placeholder("island_" + xMaterial.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
         }
+        
+        // Add entity type placeholders with null values
         for (EntityType entityType : EntityType.values()) {
-            placeholderList.add(new Placeholder("island_" + entityType.name().toLowerCase() + "_amount", IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
+            placeholderList.add(new Placeholder("island_" + entityType.name().toLowerCase() + "_amount", () -> IridiumSkyblock.getInstance().getMessages().nullPlaceholder));
         }
+        
         return placeholderList;
     }
 
     @Override
     public List<Placeholder> getPlaceholders(Optional<Island> optional) {
-        return optional.isPresent() ? getPlaceholders(optional.get()) : defaultPlaceholders;
+        if (optional.isPresent()) {
+            return getPlaceholders(optional.get());
+        } else {
+            // Generate placeholders dynamically instead of using cached ones
+            return getDefaultPlaceholders();
+        }
     }
 }


### PR DESCRIPTION
✅ Describe the contribution
This PR refactors the getDefaultPlaceholders method in IslandPlaceholderBuilder.java to return dynamic, real-time placeholder values instead of static ones.

🐛 Explain the Issue
Previously, Placeholders such as %iridiumskyblock_island_bank_money% would return default static strings when the player had no island, rather than reflecting their actual state (e.g., “N/A”). further it is an active Issue at (Placeholder issue [#969)](https://github.com/Iridium-Development/IridiumSkyblock/issues/969)

🎯 Expected Behavior
Returns "NullPlaceholder" (i.e N/A) if the player has no island.
Returns live island values (bank money, crystals, experience) when available.
Ensures better placeholder compatibility with dynamic systems.

🧪 Tested Versions
Paper 1.21.4
IridiumSkyblock latest build from GitHub
PlaceholderAPI integration tested via in-game commands and scoreboard integration 

⚠ Known Issues
None observed in local testing

🔗 Dependencies
No additional dependencies
Does not require changes in IridiumTeams or IridiumCore