### PR TITLE
Update IridiumSkyblock.java

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -152,10 +152,6 @@ public class IridiumSkyblock extends IridiumTeams<Island, User> {
             return;
         }
 
-        this.teamsPlaceholderBuilder = new IslandPlaceholderBuilder();
-        this.userPlaceholderBuilder = new UserPlaceholderBuilder();
-        this.teamChatPlaceholderBuilder = new TeamChatPlaceholderBuilder();
-
         Bukkit.getScheduler().runTask(this, () -> this.economy = setupEconomy());
 
         Bukkit.getServer().getOnlinePlayers().forEach(player -> getIslandManager().sendIslandBorder(player));
@@ -163,6 +159,9 @@ public class IridiumSkyblock extends IridiumTeams<Island, User> {
         addBstats(5825);
         startUpdateChecker(62480);
         super.onEnable();
+        this.teamsPlaceholderBuilder = new IslandPlaceholderBuilder();
+        this.userPlaceholderBuilder = new UserPlaceholderBuilder();
+        this.teamChatPlaceholderBuilder = new TeamChatPlaceholderBuilder();
     }
 
     private Economy setupEconomy() {


### PR DESCRIPTION
Describe the contribution:
Changing the placeholder initialization after  `super.onEnable();` to ensure Items like Bank Items are available at the time of usage in `IslandPlaceholderBuilder.java`

Explain the Issue:
Fix's [Placeholder issue #969 ](https://github.com/Iridium-Development/IridiumSkyblock/issues/969)

Expected Behavior:
Fix's the issue and shows the bank items placeholders when the player do not have an island

Tested Versions:
Latest Build; 1.21.4; Paper

Known Issues:
None

Dependencies:
None

(PS~ Thanks a lot @PeachesMLG for the help to understand how the the placeholder code works. and help fix it.)