### PR TITLE
Feature/deepslate generator

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Enhancements.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Enhancements.java
@@ -96,6 +96,10 @@ public class Enhancements extends com.iridium.iridiumteams.configs.Enhancements 
                             .build(),
                     ImmutableMap.<XMaterial, Integer>builder()
                             .put(XMaterial.BASALT, 1)
+                            .build(),
+                    ImmutableMap.<XMaterial, Integer>builder()
+                            .put(XMaterial.DEEPSLATE, 3)
+                            .put(XMaterial.DEEPSLATE_COAL_ORE, 1)
                             .build()))
             .put(1, new GeneratorEnhancementData(5, 10000, new ImmutableMap.Builder<String, Double>().put("Crystals", 5.00).build(),
                     ImmutableMap.<XMaterial, Integer>builder()
@@ -108,6 +112,12 @@ public class Enhancements extends com.iridium.iridiumteams.configs.Enhancements 
                             .put(XMaterial.BASALT, 20)
                             .put(XMaterial.GLOWSTONE, 20)
                             .put(XMaterial.NETHERRACK, 20)
+                            .build(),
+                    ImmutableMap.<XMaterial, Integer>builder()
+                            .put(XMaterial.DEEPSLATE_REDSTONE_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_LAPIS_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_COAL_ORE, 20)
+                            .put(XMaterial.DEEPSLATE, 40)
                             .build()))
             .put(2, new GeneratorEnhancementData(5, 10000, new ImmutableMap.Builder<String, Double>().put("Crystals", 5.00).build(),
                     ImmutableMap.<XMaterial, Integer>builder()
@@ -124,6 +134,14 @@ public class Enhancements extends com.iridium.iridiumteams.configs.Enhancements 
                             .put(XMaterial.NETHER_QUARTZ_ORE, 10)
                             .put(XMaterial.NETHER_GOLD_ORE, 10)
                             .put(XMaterial.NETHERRACK, 10)
+                            .build(),
+                    ImmutableMap.<XMaterial, Integer>builder()
+                            .put(XMaterial.DEEPSLATE_IRON_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_REDSTONE_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_GOLD_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_LAPIS_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_COAL_ORE, 20)
+                            .put(XMaterial.DEEPSLATE, 40)
                             .build()))
             .put(3, new GeneratorEnhancementData(5, 10000, new ImmutableMap.Builder<String, Double>().put("Crystals", 5.00).build(),
                     ImmutableMap.<XMaterial, Integer>builder()
@@ -142,6 +160,15 @@ public class Enhancements extends com.iridium.iridiumteams.configs.Enhancements 
                             .put(XMaterial.NETHER_GOLD_ORE, 10)
                             .put(XMaterial.NETHERRACK, 10)
                             .put(XMaterial.ANCIENT_DEBRIS, 1)
+                            .build(),
+                    ImmutableMap.<XMaterial, Integer>builder()
+                            .put(XMaterial.DEEPSLATE_DIAMOND_ORE, 3)
+                            .put(XMaterial.DEEPSLATE_IRON_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_REDSTONE_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_GOLD_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_LAPIS_ORE, 10)
+                            .put(XMaterial.DEEPSLATE_COAL_ORE, 20)
+                            .put(XMaterial.DEEPSLATE, 40)
                             .build()))
             .build());
 }

--- a/src/main/java/com/iridium/iridiumskyblock/enhancements/GeneratorEnhancementData.java
+++ b/src/main/java/com/iridium/iridiumskyblock/enhancements/GeneratorEnhancementData.java
@@ -10,10 +10,12 @@ import java.util.Map;
 public class GeneratorEnhancementData extends EnhancementData {
     public Map<XMaterial, Integer> ores;
     public Map<XMaterial, Integer> netherOres;
+    public Map<XMaterial, Integer> deepslateOres;
 
-    public GeneratorEnhancementData(int minLevel, int money, Map<String, Double> bankCosts, Map<XMaterial, Integer> ores, Map<XMaterial, Integer> netherOres) {
+    public GeneratorEnhancementData(int minLevel, int money, Map<String, Double> bankCosts, Map<XMaterial, Integer> ores, Map<XMaterial, Integer> netherOres, Map<XMaterial, Integer> deepslateOres) {
         super(minLevel, money, bankCosts);
         this.ores = ores;
         this.netherOres = netherOres;
+        this.deepslateOres = deepslateOres;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockFormListener.java
@@ -16,6 +16,7 @@ public class BlockFormListener implements Listener {
 
     private final Map<Integer, RandomAccessList<XMaterial>> normalOreLevels = new HashMap<>();
     private final Map<Integer, RandomAccessList<XMaterial>> netherOreLevels = new HashMap<>();
+    private final Map<Integer, RandomAccessList<XMaterial>> deepslateOreLevels = new HashMap<>();
 
     private final List<XMaterial> generatorMaterials = Arrays.asList(XMaterial.STONE, XMaterial.COBBLESTONE, XMaterial.BASALT);
 
@@ -23,6 +24,9 @@ public class BlockFormListener implements Listener {
         for (Map.Entry<Integer, GeneratorEnhancementData> oreUpgrade : IridiumSkyblock.getInstance().getEnhancements().generatorEnhancement.levels.entrySet()) {
             normalOreLevels.put(oreUpgrade.getKey(), new RandomAccessList<>(oreUpgrade.getValue().ores));
             netherOreLevels.put(oreUpgrade.getKey(), new RandomAccessList<>(oreUpgrade.getValue().netherOres));
+            if (oreUpgrade.getValue().deepslateOres != null) {
+                deepslateOreLevels.put(oreUpgrade.getKey(), new RandomAccessList<>(oreUpgrade.getValue().deepslateOres));
+            }
         }
     }
 
@@ -33,7 +37,10 @@ public class BlockFormListener implements Listener {
         IridiumSkyblock.getInstance().getIslandManager().getTeamViaLocation(event.getNewState().getLocation()).ifPresent(island -> {
             int upgradeLevel = IridiumSkyblock.getInstance().getIslandManager().getTeamEnhancement(island, "generator").getLevel();
             boolean isBasaltGenerator = newMaterial == XMaterial.BASALT;
-            RandomAccessList<XMaterial> randomMaterialList = isBasaltGenerator ? netherOreLevels.get(upgradeLevel) : normalOreLevels.get(upgradeLevel);
+            boolean isDeepslate = !isBasaltGenerator && event.getNewState().getY() < 0;
+            RandomAccessList<XMaterial> randomMaterialList = isBasaltGenerator ? netherOreLevels.get(upgradeLevel)
+                    : isDeepslate ? deepslateOreLevels.getOrDefault(upgradeLevel, normalOreLevels.get(upgradeLevel))
+                    : normalOreLevels.get(upgradeLevel);
             if (randomMaterialList == null) return;
 
             Optional<XMaterial> xMaterialOptional = randomMaterialList.nextElement();

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
@@ -5,7 +5,7 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.database.LostItems;
 import com.iridium.iridiumskyblock.database.User;
 import com.iridium.iridiumskyblock.enhancements.VoidEnhancementData;
-import com.iridium.iridiumteams.utils.LocationUtils;
+import com.iridium.iridiumskyblock.utils.LocationUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;

--- a/src/main/java/com/iridium/iridiumskyblock/utils/LocationUtils.java
+++ b/src/main/java/com/iridium/iridiumskyblock/utils/LocationUtils.java
@@ -84,6 +84,9 @@ public class LocationUtils {
      * @return The lowest AIR location.
      */
     public static int getMinHeight(World world) {
-        return XMaterial.getVersion() >= 17 ? world.getMinHeight() : 0;  // World#getMinHeight() -> Available only in 1.17 Spigot and 1.16.5 PaperMC
+        int major = XMaterial.getVersionMajor();
+        // This because the old version starts all with 1.x and the new version start with 26.x
+        int version = major == 1 ? XMaterial.getVersionMinor() : major;
+        return version >= 17 ? world.getMinHeight() : 0; // World#getMinHeight() -> Available only in 1.17 Spigot and 1.16.5 PaperMC
     }
 }


### PR DESCRIPTION
With this pull request i am added Add deepslate ore support for cobblestone generators below Y=0

Behavior
- Above Y=0: unchanged (stone/cobblestone + regular ores)
- Below Y=0: deepslate + deepslate ore variants
- Basalt generators: unchanged (still uses nether ore table)
- Existing configs without deepslateOres: gracefully falls back to normal ores

I have tested this on a 26.1.2 paper server
<img width="2592" height="1358" alt="2026-08-25_21 49 37" src="https://github.com/user-attachments/assets/e92604cd-2959-4534-a164-2b4081ebc8f3" />
<img width="2592" height="1358" alt="2026-08-25_21 49 17_2" src="https://github.com/user-attachments/assets/341d630a-eb6c-4f09-9b3b-4f6d455afa59" />

Ps its my first pull request here let me know if there is anything else i need to do :)

